### PR TITLE
Fixed infra teardown make target

### DIFF
--- a/infrastructure/terraform/makefile
+++ b/infrastructure/terraform/makefile
@@ -13,5 +13,6 @@ infrastructure.build:
 
 infrastructure.destroy:
 		@echo "::group::Tearing down infrastructure"
+		aws s3 rm s3://bettmensch-ai-artifact-repository --recursive
 		terraform -chdir=$(DIR) destroy -auto-approve
 		@echo "::endgroup::"


### PR DESCRIPTION
added step emptying the s3 bucket holding the argo workflow artifacts before tearing down the stack