### PR TITLE
E2e platform test

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,26 +13,25 @@ on:
       - master
 
 jobs:
-  sdk:
-    runs-on: ubuntu-latest
+  unit-test:
+    uses: ./.github/workflows/unit-test.yaml
     strategy:
       matrix:
         python-version: ["3.10", "3.11",]
+    with:
+      python-version: ${{ matrix.python-version }}
 
-    steps:
-      - uses: actions/checkout@v4
-      
-      - uses: ./.github/workflows/unit-test.yaml
-        with:
-          python-version: ${{ matrix.python-version }}
-
-      - uses: ./.github/workflows/integration-test.yaml
-        with:
-          python-version: ${{ matrix.python-version }}
+  integration-test:
+    uses: ./.github/workflows/integration-test.yaml
+    strategy:
+      matrix:
+        python-version: ["3.10", "3.11",]
+    with:
+      python-version: ${{ matrix.python-version }}
 
   docker-components:
     runs-on: ubuntu-latest
-    needs: sdk
+    needs: integration-test
     strategy:
       matrix:
         component: ["standard", "pytorch", "pytorch-lightning"]
@@ -52,7 +51,7 @@ jobs:
 
   docker-dashboard:
     runs-on: ubuntu-latest
-    needs: sdk
+    needs: integration-test
     steps:
       - uses: actions/checkout@v4
       - name: Login to Docker Hub

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,8 +19,10 @@ jobs:
   integration-test:
     uses: ./.github/workflows/integration-test.yaml
 
+  # <remove when done with testing of the underlying workflows
   k8s-test:
     uses: ./.github/workflows/k8s-test.yaml
+  # remove when done with testing of the underlying workflows>
 
   docker-components:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,6 +19,9 @@ jobs:
   integration-test:
     uses: ./.github/workflows/integration-test.yaml
 
+  k8s-test:
+    uses: ./.github/workflows/k8s-test.yaml
+
   docker-components:
     runs-on: ubuntu-latest
     needs: integration-test

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,6 +21,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+      
       - uses: ./.github/workflows/unit-test.yaml
         with:
           python-version: ${{ matrix.python-version }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,19 +15,9 @@ on:
 jobs:
   unit-test:
     uses: ./.github/workflows/unit-test.yaml
-    strategy:
-      matrix:
-        python-version: ["3.10", "3.11",]
-    with:
-      python-version: ${{ matrix.python-version }}
 
   integration-test:
     uses: ./.github/workflows/integration-test.yaml
-    strategy:
-      matrix:
-        python-version: ["3.10", "3.11",]
-    with:
-      python-version: ${{ matrix.python-version }}
 
   docker-components:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,13 +15,14 @@ on:
 jobs:
   unit-test:
     uses: ./.github/workflows/unit-test.yaml
-
+    
   integration-test:
     uses: ./.github/workflows/integration-test.yaml
-
+    
   # <remove when done with testing of the underlying workflows
   k8s-test:
     uses: ./.github/workflows/k8s-test.yaml
+    secrets: inherit
   # remove when done with testing of the underlying workflows>
 
   docker-components:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,10 +20,11 @@ jobs:
         python-version: ["3.10", "3.11",]
 
     steps:
+      - uses: actions/checkout@v4
       - uses: ./.github/workflows/unit-test.yaml
         with:
           python-version: ${{ matrix.python-version }}
-          
+
       - uses: ./.github/workflows/integration-test.yaml
         with:
           python-version: ${{ matrix.python-version }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,23 +20,13 @@ jobs:
         python-version: ["3.10", "3.11",]
 
     steps:
-      - name: Set Swap Space
-        uses: pierotofy/set-swap-space@master
-        with:
-          swap-size-gb: 10
-      - uses: actions/checkout@v4
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+      - uses: ./.github/workflows/unit-test.yaml
         with:
           python-version: ${{ matrix.python-version }}
-      - name: Installation setup
-        run: pip install setuptools
-      - name: Install sdk
-        run: make sdk.install EXTRAS=test
-      - name: Unit test sdk
-        run: make sdk.test SUITE=unit
-      - name: Integration test sdk
-        run: make sdk.test SUITE=integration
+          
+      - uses: ./.github/workflows/integration-test.yaml
+        with:
+          python-version: ${{ matrix.python-version }}
 
   docker-components:
     runs-on: ubuntu-latest
@@ -61,7 +51,6 @@ jobs:
   docker-dashboard:
     runs-on: ubuntu-latest
     needs: sdk
-
     steps:
       - uses: actions/checkout@v4
       - name: Login to Docker Hub

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,12 +18,6 @@ jobs:
     
   integration-test:
     uses: ./.github/workflows/integration-test.yaml
-    
-  # <remove when done with testing of the underlying workflows
-  k8s-test:
-    uses: ./.github/workflows/k8s-test.yaml
-    secrets: inherit
-  # remove when done with testing of the underlying workflows>
 
   docker-components:
     runs-on: ubuntu-latest

--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -1,0 +1,20 @@
+on:
+  workflow_call:
+    inputs:
+      test-flags:
+        default: "" # for the k8s test suite: "-m standard", "-m ddp" etc
+        required: false
+        type: string 
+      python-version:
+        default: "3.10" # "3.11"
+        required: false
+        type: string
+jobs:
+  platform-e2e-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: ./.github/workflows/test.yaml
+        with:
+          test-suite: integration
+          test-flags: ${{ inputs.test-flags }}
+          python-version: ${{ inputs.python-version }}

--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -10,9 +10,10 @@ on:
         required: false
         type: string
 jobs:
-  platform-e2e-test:
+  integration-test:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v4
       - uses: ./.github/workflows/test.yaml
         with:
           test-suite: integration

--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -12,11 +12,8 @@ on:
 jobs:
   integration-test:
     runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      
-      - uses: ./.github/workflows/test.yaml
-        with:
-          test-suite: integration
-          test-flags: ${{ inputs.test-flags }}
-          python-version: ${{ inputs.python-version }}
+    uses: ./.github/workflows/test.yaml
+    with:
+      test-suite: integration
+      test-flags: ${{ inputs.test-flags }}
+      python-version: ${{ inputs.python-version }}

--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -11,7 +11,6 @@ on:
         type: string
 jobs:
   integration-test:
-    runs-on: ubuntu-latest
     uses: ./.github/workflows/test.yaml
     with:
       test-suite: integration

--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -14,6 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      
       - uses: ./.github/workflows/test.yaml
         with:
           test-suite: integration

--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -9,9 +9,16 @@ on:
         default: "3.10" # "3.11"
         required: false
         type: string
+    secrets:
+      AWS_ACCESS_KEY_ID:
+        required: false
+      AWS_SECRET_ACCESS_KEY:
+        required: false
+
 jobs:
   integration-test:
     uses: ./.github/workflows/test.yaml
+    secrets: inherit
     with:
       test-suite: integration
       test-flags: ${{ inputs.test-flags }}

--- a/.github/workflows/k8s-test.yaml
+++ b/.github/workflows/k8s-test.yaml
@@ -25,6 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      
       - uses: ./.github/workflows/test.yaml
         with:
           test-suite: k8s

--- a/.github/workflows/k8s-test.yaml
+++ b/.github/workflows/k8s-test.yaml
@@ -1,26 +1,37 @@
+# on:
+#   workflow_dispatch:
+#     inputs:
+#       test-flags:
+#         default: "" # for the k8s test suite: "-m standard", "-m ddp" etc
+#         required: false
+#         type: choice
+#         options:
+#         - ""
+#         - "-m standard"
+#         - "-m ddp"
+#         - "-m delete_pipelines"
+#         - "-m delete_flows"
+
+#       python-version:
+#         default: "3.10" # "3.11"
+#         required: false
+#         type: choice
+#         options:
+#         - "3.10"
+#         - "3.11"
+#         - "3.12"
 on:
-  workflow_dispatch:
+  workflow_call:
     inputs:
       test-flags:
         default: "" # for the k8s test suite: "-m standard", "-m ddp" etc
         required: false
-        type: choice
-        options:
-        - ""
-        - "-m standard"
-        - "-m ddp"
-        - "-m delete_pipelines"
-        - "-m delete_flows"
-
+        type: string 
       python-version:
         default: "3.10" # "3.11"
         required: false
-        type: choice
-        options:
-        - "3.10"
-        - "3.11"
-        - "3.12"
-
+        type: string
+        
 jobs:
   k8s-test:
     uses: ./.github/workflows/test.yaml

--- a/.github/workflows/k8s-test.yaml
+++ b/.github/workflows/k8s-test.yaml
@@ -20,14 +20,12 @@ on:
         - "3.10"
         - "3.11"
         - "3.12"
+        
 jobs:
   k8s-test:
     runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      
-      - uses: ./.github/workflows/test.yaml
-        with:
-          test-suite: k8s
-          test-flags: ${{ inputs.test-flags }}
-          python-version: ${{ inputs.python-version }}
+    uses: ./.github/workflows/test.yaml
+    with:
+      test-suite: k8s
+      test-flags: ${{ inputs.test-flags }}
+      python-version: ${{ inputs.python-version }}

--- a/.github/workflows/k8s-test.yaml
+++ b/.github/workflows/k8s-test.yaml
@@ -1,36 +1,25 @@
-# on:
-#   workflow_dispatch:
-#     inputs:
-#       test-flags:
-#         default: "" # for the k8s test suite: "-m standard", "-m ddp" etc
-#         required: false
-#         type: choice
-#         options:
-#         - ""
-#         - "-m standard"
-#         - "-m ddp"
-#         - "-m delete_pipelines"
-#         - "-m delete_flows"
-
-#       python-version:
-#         default: "3.10" # "3.11"
-#         required: false
-#         type: choice
-#         options:
-#         - "3.10"
-#         - "3.11"
-#         - "3.12"
 on:
-  workflow_call:
+  workflow_dispatch:
     inputs:
       test-flags:
         default: "" # for the k8s test suite: "-m standard", "-m ddp" etc
         required: false
-        type: string 
+        type: choice
+        options:
+        - ""
+        - "-m standard"
+        - "-m ddp"
+        - "-m delete_pipelines"
+        - "-m delete_flows"
+
       python-version:
         default: "3.10" # "3.11"
         required: false
-        type: string
+        type: choice
+        options:
+        - "3.10"
+        - "3.11"
+        - "3.12"
     secrets:
       AWS_ACCESS_KEY_ID:
         required: false

--- a/.github/workflows/k8s-test.yaml
+++ b/.github/workflows/k8s-test.yaml
@@ -20,10 +20,9 @@ on:
         - "3.10"
         - "3.11"
         - "3.12"
-        
+
 jobs:
   k8s-test:
-    runs-on: ubuntu-latest
     uses: ./.github/workflows/test.yaml
     with:
       test-suite: k8s

--- a/.github/workflows/k8s-test.yaml
+++ b/.github/workflows/k8s-test.yaml
@@ -31,10 +31,16 @@ on:
         default: "3.10" # "3.11"
         required: false
         type: string
-        
+    secrets:
+      AWS_ACCESS_KEY_ID:
+        required: false
+      AWS_SECRET_ACCESS_KEY:
+        required: false
+
 jobs:
   k8s-test:
     uses: ./.github/workflows/test.yaml
+    secrets: inherit
     with:
       test-suite: k8s
       test-flags: ${{ inputs.test-flags }}

--- a/.github/workflows/k8s-test.yaml
+++ b/.github/workflows/k8s-test.yaml
@@ -21,9 +21,10 @@ on:
         - "3.11"
         - "3.12"
 jobs:
-  platform-e2e-test:
+  k8s-test:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v4
       - uses: ./.github/workflows/test.yaml
         with:
           test-suite: k8s

--- a/.github/workflows/platform-e2e-test.yaml
+++ b/.github/workflows/platform-e2e-test.yaml
@@ -1,0 +1,31 @@
+on:
+  workflow_dispatch:
+    inputs:
+      test-flags:
+        default: "" # for the k8s test suite: "-m standard", "-m ddp" etc
+        required: false
+        type: choice
+        options:
+        - ""
+        - "-m standard"
+        - "-m ddp"
+        - "-m delete_pipelines"
+        - "-m delete_flows"
+
+      python-version:
+        default: "3.10" # "3.11"
+        required: false
+        type: choice
+        options:
+        - "3.10"
+        - "3.11"
+        - "3.12"
+jobs:
+  platform-e2e-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: ./.github/workflows/test.yaml
+        with:
+          test-suite: k8s
+          test-flags: ${{ inputs.test-flags }}
+          python-version: ${{ inputs.python-version }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,0 +1,61 @@
+on:
+  workflow_call:
+    inputs:
+      test-suite:
+        default: "unit" # "integration", "k8s"
+        required: true
+        type: string
+      test-flags:
+        default: "" # for the k8s test suite: "-m standard", "-m ddp" etc
+        required: false
+        type: string 
+      python-version:
+        default: "3.10" # "3.11"
+        required: false
+        type: string
+jobs:
+  sdk:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set Swap Space
+        uses: pierotofy/set-swap-space@master
+        with:
+          swap-size-gb: 10
+
+      - uses: actions/checkout@v4
+      
+      - name: Set up Python ${{ inputs.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ inputs.python-version }}
+      
+      - name: Installation setup
+        run: pip install setuptools
+      
+      - name: Install sdk
+        run: make sdk.install EXTRAS=test
+
+      - name: Install terraform
+        if: ${{ inputs.test-suite == 'k8s' }}
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: "1.9.8"
+
+      - name: Configure AWS Credentials
+        if: ${{ inputs.test-suite == 'k8s' }}
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-east-2
+        
+      - name: Boot up platform & connect
+        if: ${{ inputs.test-suite == 'k8s' }}
+        run: make platform.up & make platform.connect
+      
+      - name: Run test suite
+        run: make sdk.test SUITE=${{ inputs.test-suite }} PYTEST_FLAGS=${{ inputs.test-flags }}
+      
+      - name: Bring down platform
+        if: ${{ inputs.test-suite == 'k8s' }}
+        run: make platform.down

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -14,7 +14,7 @@ on:
         required: false
         type: string
 jobs:
-  sdk:
+  test:
     runs-on: ubuntu-latest
     steps:
       - name: Set Swap Space

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -41,6 +41,10 @@ jobs:
         with:
           terraform_version: "1.9.8"
 
+      - run: echo ${{ secrets.AWS_ACCESS_KEY_ID}}
+
+      - run: echo ${{ secrets.AWS_SECRET_ACCESS_KEY}}
+
       - name: Configure AWS Credentials
         if: ${{ inputs.test-suite == 'k8s' }}
         uses: aws-actions/configure-aws-credentials@v4

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -29,17 +29,6 @@ jobs:
 
       - uses: actions/checkout@v4
       
-      - name: Set up Python ${{ inputs.python-version }}
-        uses: actions/setup-python@v5
-        with:
-          python-version: ${{ inputs.python-version }}
-      
-      - name: Installation setup
-        run: pip install setuptools
-      
-      - name: Install sdk
-        run: make sdk.install EXTRAS=test
-
       - name: Install terraform
         if: ${{ inputs.test-suite == 'k8s' }}
         uses: hashicorp/setup-terraform@v3
@@ -61,6 +50,17 @@ jobs:
       - name: Boot up platform & connect
         if: ${{ inputs.test-suite == 'k8s' }}
         run: make platform.up & make platform.connect
+
+      - name: Set up Python ${{ inputs.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ inputs.python-version }}
+      
+      - name: Installation setup
+        run: pip install setuptools
+      
+      - name: Install sdk
+        run: make sdk.install EXTRAS=test
       
       - name: Run test suite
         run: make sdk.test SUITE=${{ inputs.test-suite }} PYTEST_FLAGS=${{ inputs.test-flags }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -13,6 +13,11 @@ on:
         default: "3.10" # "3.11"
         required: false
         type: string
+    secrets:
+      AWS_ACCESS_KEY_ID:
+        required: false
+      AWS_SECRET_ACCESS_KEY:
+        required: false
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -49,7 +49,7 @@ jobs:
         
       - name: Boot up platform & connect
         if: ${{ inputs.test-suite == 'k8s' }}
-        run: make platform.up & make platform.connect
+        run: make platform.up && make platform.connect
 
       - name: Set up Python ${{ inputs.python-version }}
         uses: actions/setup-python@v5

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -47,23 +47,23 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: us-east-2
         
-      - name: Boot up platform & connect
-        if: ${{ inputs.test-suite == 'k8s' }}
-        run: make platform.up && make platform.connect
+      # - name: Boot up platform & connect
+      #   if: ${{ inputs.test-suite == 'k8s' }}
+      #   run: make platform.up && make platform.connect
 
-      - name: Set up Python ${{ inputs.python-version }}
-        uses: actions/setup-python@v5
-        with:
-          python-version: ${{ inputs.python-version }}
+      # - name: Set up Python ${{ inputs.python-version }}
+      #   uses: actions/setup-python@v5
+      #   with:
+      #     python-version: ${{ inputs.python-version }}
       
-      - name: Installation setup
-        run: pip install setuptools
+      # - name: Installation setup
+      #   run: pip install setuptools
       
-      - name: Install sdk
-        run: make sdk.install EXTRAS=test
+      # - name: Install sdk
+      #   run: make sdk.install EXTRAS=test
       
-      - name: Run test suite
-        run: make sdk.test SUITE=${{ inputs.test-suite }} PYTEST_FLAGS=${{ inputs.test-flags }}
+      # - name: Run test suite
+      #   run: make sdk.test SUITE=${{ inputs.test-suite }} PYTEST_FLAGS=${{ inputs.test-flags }}
       
       - name: Bring down platform
         if: ${{ inputs.test-suite == 'k8s' }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -67,4 +67,4 @@ jobs:
       
       - name: Bring down platform
         if: ${{ inputs.test-suite == 'k8s' }}
-        run: make platform.down
+        run: make platform.init && make platform.down

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -28,16 +28,6 @@ jobs:
           swap-size-gb: 10
 
       - uses: actions/checkout@v4
-      
-      - name: Install terraform
-        if: ${{ inputs.test-suite == 'k8s' }}
-        uses: hashicorp/setup-terraform@v3
-        with:
-          terraform_version: "1.9.8"
-
-      - run: echo ${{ secrets.AWS_ACCESS_KEY_ID}}
-
-      - run: echo ${{ secrets.AWS_SECRET_ACCESS_KEY}}
 
       - name: Configure AWS Credentials
         if: ${{ inputs.test-suite == 'k8s' }}
@@ -47,24 +37,20 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: us-east-2
         
-      # - name: Boot up platform & connect
-      #   if: ${{ inputs.test-suite == 'k8s' }}
-      #   run: make platform.up && make platform.connect
-
-      # - name: Set up Python ${{ inputs.python-version }}
-      #   uses: actions/setup-python@v5
-      #   with:
-      #     python-version: ${{ inputs.python-version }}
-      
-      # - name: Installation setup
-      #   run: pip install setuptools
-      
-      # - name: Install sdk
-      #   run: make sdk.install EXTRAS=test
-      
-      # - name: Run test suite
-      #   run: make sdk.test SUITE=${{ inputs.test-suite }} PYTEST_FLAGS=${{ inputs.test-flags }}
-      
-      - name: Bring down platform
+      - name: Connect to platform
         if: ${{ inputs.test-suite == 'k8s' }}
-        run: make platform.init && make platform.down
+        run: make platform.connect
+
+      - name: Set up Python ${{ inputs.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ inputs.python-version }}
+      
+      - name: Installation setup
+        run: pip install setuptools
+      
+      - name: Install sdk
+        run: make sdk.install EXTRAS=test
+      
+      - name: Run test suite
+        run: make sdk.test SUITE=${{ inputs.test-suite }} PYTEST_FLAGS=${{ inputs.test-flags }}

--- a/.github/workflows/unit-test.yaml
+++ b/.github/workflows/unit-test.yaml
@@ -9,9 +9,15 @@ on:
         default: "3.10" # "3.11"
         required: false
         type: string
+    secrets:
+      AWS_ACCESS_KEY_ID:
+        required: false
+      AWS_SECRET_ACCESS_KEY:
+        required: false
 jobs:
   unit-test:
     uses: ./.github/workflows/test.yaml
+    secrets: inherit
     with:
       test-suite: unit
       test-flags: ${{ inputs.test-flags }}

--- a/.github/workflows/unit-test.yaml
+++ b/.github/workflows/unit-test.yaml
@@ -14,6 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      
       - uses: ./.github/workflows/test.yaml
         with:
           test-suite: unit

--- a/.github/workflows/unit-test.yaml
+++ b/.github/workflows/unit-test.yaml
@@ -10,9 +10,10 @@ on:
         required: false
         type: string
 jobs:
-  platform-e2e-test:
+  unit-test:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v4
       - uses: ./.github/workflows/test.yaml
         with:
           test-suite: unit

--- a/.github/workflows/unit-test.yaml
+++ b/.github/workflows/unit-test.yaml
@@ -12,11 +12,8 @@ on:
 jobs:
   unit-test:
     runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      
-      - uses: ./.github/workflows/test.yaml
-        with:
-          test-suite: unit
-          test-flags: ${{ inputs.test-flags }}
-          python-version: ${{ inputs.python-version }}
+    uses: ./.github/workflows/test.yaml
+    with:
+      test-suite: unit
+      test-flags: ${{ inputs.test-flags }}
+      python-version: ${{ inputs.python-version }}

--- a/.github/workflows/unit-test.yaml
+++ b/.github/workflows/unit-test.yaml
@@ -1,0 +1,20 @@
+on:
+  workflow_call:
+    inputs:
+      test-flags:
+        default: "" # for the k8s test suite: "-m standard", "-m ddp" etc
+        required: false
+        type: string 
+      python-version:
+        default: "3.10" # "3.11"
+        required: false
+        type: string
+jobs:
+  platform-e2e-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: ./.github/workflows/test.yaml
+        with:
+          test-suite: unit
+          test-flags: ${{ inputs.test-flags }}
+          python-version: ${{ inputs.python-version }}

--- a/.github/workflows/unit-test.yaml
+++ b/.github/workflows/unit-test.yaml
@@ -11,7 +11,6 @@ on:
         type: string
 jobs:
   unit-test:
-    runs-on: ubuntu-latest
     uses: ./.github/workflows/test.yaml
     with:
       test-suite: unit

--- a/infrastructure/terraform/makefile
+++ b/infrastructure/terraform/makefile
@@ -1,6 +1,4 @@
 ## VARIABLES
-REGION?=us-east-2
-CLUSTER_NAME?=bettmensch-ai
 DIR?=infrastructure/terraform
 
 platform.init:
@@ -17,13 +15,18 @@ platform.up:
 	make platform.init DIR=$(DIR)
 	make platform.plan DIR=$(DIR)
 	terraform -chdir=$(DIR) apply -auto-approve
-	aws eks --region $(REGION) update-kubeconfig --name $(CLUSTER_NAME)
 	@echo "::endgroup::"
 
 platform.connect:
-	@echo "::group::Port forwarding to argo and mlflow platform components"
+	@echo "::group::Connecting to the platform..."
+	make kubernetes.configure
 	make kubernetes.connect
 	@echo "::endgroup::
+
+platform.test:
+	@echo "::group:: Running e2e platform tests"
+	make sdk.test SUITE=k8s PYTEST_FLAGS=$(PYTEST_FLAGS)
+	@echo "::endgroup::"
 
 platform.delete_pipelines:
 	@echo "::group:: Removing all pipelines"

--- a/infrastructure/terraform/makefile
+++ b/infrastructure/terraform/makefile
@@ -35,3 +35,11 @@ platform.test:
 		make sdk.test SUITE=k8s PYTEST_FLAGS=$(PYTEST_FLAGS)
 		# make platform.down
 		@echo "::endgroup::"
+
+platform.delete_pipelines:
+		@echo "::group:: Removing all pipelines"
+		make sdk.test SUITE=k8s PYTEST_FLAGS="-m delete_pipelines"
+
+platform.delete_flows:
+		@echo "::group:: Removing all flows"
+		make sdk.test SUITE=k8s PYTEST_FLAGS="-m delete_flows"

--- a/infrastructure/terraform/makefile
+++ b/infrastructure/terraform/makefile
@@ -18,28 +18,32 @@ platform.up:
 	make platform.plan DIR=$(DIR)
 	terraform -chdir=$(DIR) apply -auto-approve
 	aws eks --region $(REGION) update-kubeconfig --name $(CLUSTER_NAME)
-	make kubernetes.connect
 	@echo "::endgroup::"
 
-platform.down:
-		@echo "::group::Tearing down platform infrastructure..."
-		# empty the argo workflow artifact repository s3 bucket, otherwise we
-		# wont be able to remove it from AWS
-		aws s3 rm s3://bettmensch-ai-artifact-repository --recursive
-		terraform -chdir=$(DIR) destroy -auto-approve
-		@echo "::endgroup::"
+platform.connect:
+	@echo "::group::Port forwarding to argo and mlflow platform components"
+	make kubernetes.connect
+	@echo "::endgroup::
 
 platform.test:
-		@echo "::group::E2E testing platform..."
-		make platform.up
-		make sdk.test SUITE=k8s PYTEST_FLAGS=$(PYTEST_FLAGS)
-		# make platform.down
-		@echo "::endgroup::"
+	@echo "::group::E2E testing platform..."
+	make sdk.test SUITE=k8s PYTEST_FLAGS=$(PYTEST_FLAGS)
+	@echo "::endgroup::"
 
 platform.delete_pipelines:
-		@echo "::group:: Removing all pipelines"
-		make sdk.test SUITE=k8s PYTEST_FLAGS="-m delete_pipelines"
+	@echo "::group:: Removing all pipelines"
+	make sdk.test SUITE=k8s PYTEST_FLAGS="-m delete_pipelines"
+	@echo "::endgroup::"
 
 platform.delete_flows:
-		@echo "::group:: Removing all flows"
-		make sdk.test SUITE=k8s PYTEST_FLAGS="-m delete_flows"
+	@echo "::group:: Removing all flows"
+	make sdk.test SUITE=k8s PYTEST_FLAGS="-m delete_flows"
+	@echo "::endgroup::"
+	
+platform.down:
+	@echo "::group::Tearing down platform infrastructure..."
+	# empty the argo workflow artifact repository s3 bucket, otherwise we
+	# wont be able to remove it from AWS
+	aws s3 rm s3://bettmensch-ai-artifact-repository --recursive
+	terraform -chdir=$(DIR) destroy -auto-approve
+	@echo "::endgroup::"

--- a/infrastructure/terraform/makefile
+++ b/infrastructure/terraform/makefile
@@ -25,11 +25,6 @@ platform.connect:
 	make kubernetes.connect
 	@echo "::endgroup::
 
-platform.test:
-	@echo "::group::E2E testing platform..."
-	make sdk.test SUITE=k8s PYTEST_FLAGS=$(PYTEST_FLAGS)
-	@echo "::endgroup::"
-
 platform.delete_pipelines:
 	@echo "::group:: Removing all pipelines"
 	make sdk.test SUITE=k8s PYTEST_FLAGS="-m delete_pipelines"
@@ -39,7 +34,7 @@ platform.delete_flows:
 	@echo "::group:: Removing all flows"
 	make sdk.test SUITE=k8s PYTEST_FLAGS="-m delete_flows"
 	@echo "::endgroup::"
-	
+
 platform.down:
 	@echo "::group::Tearing down platform infrastructure..."
 	# empty the argo workflow artifact repository s3 bucket, otherwise we

--- a/infrastructure/terraform/makefile
+++ b/infrastructure/terraform/makefile
@@ -18,6 +18,7 @@ platform.up:
 	make platform.plan DIR=$(DIR)
 	terraform -chdir=$(DIR) apply -auto-approve
 	aws eks --region $(REGION) update-kubeconfig --name $(CLUSTER_NAME)
+	make kubernetes.connect
 	@echo "::endgroup::"
 
 platform.down:
@@ -31,7 +32,6 @@ platform.down:
 platform.test:
 		@echo "::group::E2E testing platform..."
 		make platform.up
-		make kubernetes.connect.argo
-		make sdk.test SUITE=k8s
+		make sdk.test SUITE=k8s PYTEST_FLAGS=$(PYTEST_FLAGS)
 		# make platform.down
 		@echo "::endgroup::"

--- a/infrastructure/terraform/makefile
+++ b/infrastructure/terraform/makefile
@@ -3,18 +3,35 @@ REGION?=us-east-2
 CLUSTER_NAME?=bettmensch-ai
 DIR?=infrastructure/terraform
 
-infrastructure.build:
-	@echo "::group::Building infrastructure"
+platform.init:
+	@echo "::group::Initializing platform infrastructure environment"
 	terraform -chdir=$(DIR) init
+		@echo "::endgroup::"
+
+platform.plan:
+	@echo "::group::Planning platform infrastructure"
 	terraform -chdir=$(DIR) plan
+
+platform.up:
+	@echo "::group::Bringing up platform infrastructure..."
+	make platform.init DIR=$(DIR)
+	make platform.plan DIR=$(DIR)
 	terraform -chdir=$(DIR) apply -auto-approve
 	aws eks --region $(REGION) update-kubeconfig --name $(CLUSTER_NAME)
 	@echo "::endgroup::"
 
-infrastructure.destroy:
-		@echo "::group::Tearing down infrastructure"
+platform.down:
+		@echo "::group::Tearing down platform infrastructure..."
 		# empty the argo workflow artifact repository s3 bucket, otherwise we
 		# wont be able to remove it from AWS
 		aws s3 rm s3://bettmensch-ai-artifact-repository --recursive
 		terraform -chdir=$(DIR) destroy -auto-approve
+		@echo "::endgroup::"
+
+platform.test:
+		@echo "::group::E2E testing platform..."
+		make platform.up
+		make kubernetes.connect.argo
+		make sdk.test SUITE=k8s
+		# make platform.down
 		@echo "::endgroup::"

--- a/kubernetes/makefile
+++ b/kubernetes/makefile
@@ -6,10 +6,10 @@ MLFLOW_PORT?=5000
 
 kubernetes.connect.mlflow:
 	@echo "::group::Port fowarding the Mlflow server on the K8s cluster"
-	kubectl -n mlflow port-forward $(MLFLOW_HEAD_POD) --address 0.0.0.0 $(MLFLOW_PORT):$(MLFLOW_PORT)
+	kubectl -n mlflow port-forward $(MLFLOW_HEAD_POD) --address 0.0.0.0 $(MLFLOW_PORT):$(MLFLOW_PORT) > mlflow-port-forward.log & # background process
 	@echo "::endgroup::"
 
 kubernetes.connect.argo:
 	@echo "::group::Port forwarding the ArgoWorkflows server to the K8s cluster"
-	kubectl -n argo port-forward $(ARGO_HEAD_POD) --address 0.0.0.0 $(ARGO_PORT):$(ARGO_PORT)
+	kubectl -n argo port-forward $(ARGO_HEAD_POD) --address 0.0.0.0 $(ARGO_PORT):$(ARGO_PORT) > argo-port-forward.log & # background process
 	@echo "::endgroup::"

--- a/kubernetes/makefile
+++ b/kubernetes/makefile
@@ -15,5 +15,5 @@ kubernetes.connect.argo:
 	@echo "::endgroup::"
 
 kubernetes.connect:
-	kubernetes.connect.mlflow
-	kubernetes.connect.argo
+	make kubernetes.connect.mlflow
+	make kubernetes.connect.argo

--- a/kubernetes/makefile
+++ b/kubernetes/makefile
@@ -13,3 +13,7 @@ kubernetes.connect.argo:
 	@echo "::group::Port forwarding the ArgoWorkflows server to the K8s cluster"
 	kubectl -n argo port-forward $(ARGO_HEAD_POD) --address 0.0.0.0 $(ARGO_PORT):$(ARGO_PORT) > argo-port-forward.log & # background process
 	@echo "::endgroup::"
+
+kubernetes.connect:
+	kubernetes.connect.mlflow
+	kubernetes.connect.argo

--- a/kubernetes/makefile
+++ b/kubernetes/makefile
@@ -1,8 +1,15 @@
 ## VARIABLES
+REGION?=us-east-2
+CLUSTER_NAME?=bettmensch-ai
 ARGO_HEAD_POD=$(shell kubectl get pods --selector=app=argo-server -n argo -o custom-columns=POD:metadata.name --no-headers)
 ARGO_PORT?=2746
 MLFLOW_HEAD_POD=$(shell kubectl get pods --selector=app=mlflow-server -n mlflow -o custom-columns=POD:metadata.name --no-headers)
 MLFLOW_PORT?=5000
+
+kubernetes.configure:
+	@echo "::group::Configuring kubeconfig"
+	aws eks --region $(REGION) update-kubeconfig --name $(CLUSTER_NAME)
+	@echo "::endgroup::"
 
 kubernetes.connect.mlflow:
 	@echo "::group::Port fowarding the Mlflow server on the K8s cluster"

--- a/sdk/bettmensch_ai/components/torch_ddp_component.py
+++ b/sdk/bettmensch_ai/components/torch_ddp_component.py
@@ -201,11 +201,11 @@ class TorchDDPComponent(BaseComponent):
                 value="INFO",
             ),
             Env(
-                name=f"{LaunchConfigSettings.model_config['env_prefix']}torch_min_nodes",  # noqa: E501
+                name=f"{LaunchConfigSettings.model_config['env_prefix']}_min_nodes",  # noqa: E501
                 value=self.min_nodes,
             ),
             Env(
-                name=f"{LaunchConfigSettings.model_config['env_prefix']}torch_max_nodes",  # noqa: E501
+                name=f"{LaunchConfigSettings.model_config['env_prefix']}_max_nodes",  # noqa: E501
                 value=self.n_nodes,
             ),
             Env(

--- a/sdk/bettmensch_ai/components/torch_ddp_component.py
+++ b/sdk/bettmensch_ai/components/torch_ddp_component.py
@@ -201,11 +201,11 @@ class TorchDDPComponent(BaseComponent):
                 value="INFO",
             ),
             Env(
-                name=f"{LaunchConfigSettings.model_config['env_prefix']}_min_nodes",  # noqa: E501
+                name=f"{LaunchConfigSettings.model_config['env_prefix']}min_nodes",  # noqa: E501
                 value=self.min_nodes,
             ),
             Env(
-                name=f"{LaunchConfigSettings.model_config['env_prefix']}_max_nodes",  # noqa: E501
+                name=f"{LaunchConfigSettings.model_config['env_prefix']}max_nodes",  # noqa: E501
                 value=self.n_nodes,
             ),
             Env(

--- a/sdk/bettmensch_ai/pipelines/__init__.py
+++ b/sdk/bettmensch_ai/pipelines/__init__.py
@@ -1,4 +1,10 @@
 from bettmensch_ai.pipelines.client import hera_client  # noqa: F401
+from bettmensch_ai.pipelines.flow import (  # noqa: F401
+    Flow,
+    delete_flow,
+    get_flow,
+    list_flows,
+)
 from bettmensch_ai.pipelines.pipeline import (  # noqa: F401
     Pipeline,
     delete_registered_pipeline,

--- a/sdk/bettmensch_ai/pipelines/flow.py
+++ b/sdk/bettmensch_ai/pipelines/flow.py
@@ -16,6 +16,10 @@ class Flow(object):
 
         self.registered_flow = registered_flow
 
+    @property
+    def registered_name(self) -> str:
+        return self.registered_flow.name
+
     @classmethod
     def from_workflow(cls, workflow: Workflow) -> "Flow":
         """Class method to initialize a Flow instance from a
@@ -58,7 +62,6 @@ def get_flow(
 
 def list_flows(
     registered_namespace: Optional[str] = None,
-    registered_name_pattern: Optional[str] = None,
     label_selector: Optional[str] = None,
     field_selector: Optional[str] = None,
     **kwargs,
@@ -71,7 +74,6 @@ def list_flows(
 
     response = hera_client.list_workflows(
         namespace=registered_namespace,
-        name_pattern=registered_name_pattern,
         label_selector=label_selector,
         field_selector=field_selector,
         **kwargs,

--- a/sdk/makefile
+++ b/sdk/makefile
@@ -1,7 +1,7 @@
 ## VARIABLES
-SUITE?=unit# unit,integration,k8s
 EXTRAS?=pipelines# see sdk's setup.py for all options
-
+SUITE?=unit# unit,integration,k8s
+PYTEST_FLAGS?= # e.g. "-m basic", "-m ddp" for k8s suite
 sdk.install:
 	@echo "::group::Installing sdk with $(EXTRAS) extras"
 	pip install ./sdk[$(EXTRAS)]
@@ -10,5 +10,5 @@ sdk.install:
 sdk.test:
 	@echo "::group::Running sdk $(SUITE) test suite"
 	@echo "::group:: Commit: $(COMMIT)"
-	pytest ./sdk/test/$(SUITE)/ -vv -rfEs
+	pytest ./sdk/test/$(SUITE)/ -vv -rfEs $(PYTEST_FLAGS)
 	@echo "::endgroup::"

--- a/sdk/makefile
+++ b/sdk/makefile
@@ -1,7 +1,7 @@
 ## VARIABLES
 EXTRAS?=pipelines# see sdk's setup.py for all options
 SUITE?=unit# unit,integration,k8s
-PYTEST_FLAGS?= # e.g. "-m basic", "-m ddp" for k8s suite
+PYTEST_FLAGS?= # e.g. "-m standard", "-m ddp" for k8s suite
 sdk.install:
 	@echo "::group::Installing sdk with $(EXTRAS) extras"
 	pip install ./sdk[$(EXTRAS)]

--- a/sdk/test/k8s/test_flow.py
+++ b/sdk/test/k8s/test_flow.py
@@ -3,7 +3,7 @@ from bettmensch_ai.pipelines import delete_flow, list_flows
 
 
 @pytest.mark.delete_flows
-@pytest.mark.order(1)
+@pytest.mark.order(10)
 def test_delete(test_namespace):
     """Test the pipeline.delete function"""
 

--- a/sdk/test/k8s/test_flow.py
+++ b/sdk/test/k8s/test_flow.py
@@ -1,0 +1,18 @@
+import pytest
+from bettmensch_ai.pipelines import delete_flow, list_flows
+
+
+@pytest.mark.delete_flows
+@pytest.mark.order(1)
+def test_delete(test_namespace):
+    """Test the pipeline.delete function"""
+
+    flows = list_flows(registered_namespace=test_namespace)
+
+    for flow in flows:
+        delete_flow(
+            registered_name=flow.registered_name,
+            registered_namespace=test_namespace,
+        )
+
+    assert list_flows(registered_namespace=test_namespace) == []

--- a/sdk/test/k8s/test_pipeline.py
+++ b/sdk/test/k8s/test_pipeline.py
@@ -16,7 +16,7 @@ from bettmensch_ai.pipelines import (
 )
 
 
-@pytest.mark.basic
+@pytest.mark.standard
 @pytest.mark.order(1)
 def test_artifact_pipeline_decorator_and_register_and_run(
     test_output_dir, test_namespace
@@ -66,7 +66,7 @@ def test_artifact_pipeline_decorator_and_register_and_run(
     assert parameter_to_artifact_flow.status.phase == "Succeeded"
 
 
-@pytest.mark.basic
+@pytest.mark.standard
 @pytest.mark.order(2)
 def test_parameter_pipeline_decorator_and_register_and_run(
     test_output_dir, test_namespace
@@ -113,7 +113,7 @@ def test_parameter_pipeline_decorator_and_register_and_run(
     assert adding_parameters_flow.status.phase == "Succeeded"
 
 
-@pytest.mark.basic
+@pytest.mark.standard
 @pytest.mark.order(3)
 @pytest.mark.parametrize(
     "test_registered_pipeline_name_pattern,test_n_registered_pipelines",
@@ -123,7 +123,7 @@ def test_parameter_pipeline_decorator_and_register_and_run(
         ("test-", 2),
     ],
 )
-def test_list_registered_basic_pipelines(
+def test_list_registered_standard_pipelines(
     test_namespace,
     test_registered_pipeline_name_pattern,
     test_n_registered_pipelines,
@@ -145,6 +145,7 @@ def test_list_registered_basic_pipelines(
         assert registered_pipeline.registered_namespace == test_namespace
 
 
+@pytest.mark.standard
 @pytest.mark.order(4)
 @pytest.mark.parametrize(
     "test_registered_pipeline_name_pattern,test_pipeline_inputs",
@@ -158,7 +159,7 @@ def test_list_registered_basic_pipelines(
         ("test-parameter-pipeline-", {"a": -10, "b": 20}),
     ],
 )
-def test_run_basic_registered_pipelines_from_registry(
+def test_run_standard_registered_pipelines_from_registry(
     test_namespace, test_registered_pipeline_name_pattern, test_pipeline_inputs
 ):
     """Test the pipeline.get function, and the Pipeline's constructor when
@@ -331,6 +332,7 @@ def test_lightning_ddp_pipeline_decorator_and_register_and_run(
     assert lightning_ddp_flow.status.phase == "Succeeded"
 
 
+@pytest.mark.ddp
 @pytest.mark.order(7)
 @pytest.mark.parametrize(
     "test_registered_pipeline_name_pattern,test_n_registered_pipelines",
@@ -363,6 +365,7 @@ def test_list_registered_ddp_pipelines(
         assert registered_pipeline.registered_namespace == test_namespace
 
 
+@pytest.mark.ddp
 @pytest.mark.order(8)
 @pytest.mark.parametrize(
     "test_registered_pipeline_name_pattern,test_pipeline_inputs",
@@ -411,7 +414,7 @@ def test_run_all_registered_pipelines_from_registry(
     assert flow.status.phase == "Succeeded"
 
 
-@pytest.mark.basic
+@pytest.mark.standard
 @pytest.mark.ddp
 @pytest.mark.order(9)
 def test_delete(test_namespace):

--- a/sdk/test/k8s/test_pipeline.py
+++ b/sdk/test/k8s/test_pipeline.py
@@ -388,7 +388,7 @@ def test_list_registered_ddp_pipelines(
         ),
     ],
 )
-def test_run_all_registered_pipelines_from_registry(
+def test_run_dpp_registered_pipelines_from_registry(
     test_namespace, test_registered_pipeline_name_pattern, test_pipeline_inputs
 ):
     """Test the pipeline.get function, and the Pipeline's constructor when


### PR DESCRIPTION
Refactoring and improving the CI files, make targets and k8s test suite to generate
- a CI file that boots up the platform, run the k8s tests against it, and deprovisions the platform again
- individual CI files for 
  - unit
  - integration test suites

this way we can create individual badges on the readme to display status of unit, integration and e2e platform tests individually