### PR TITLE
Fix ci flow badges

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -13,15 +13,9 @@ on:
       - master
 
 jobs:
-  unit-test:
-    uses: ./.github/workflows/unit-test.yaml
-    
-  integration-test:
-    uses: ./.github/workflows/integration-test.yaml
 
   docker-components:
     runs-on: ubuntu-latest
-    needs: integration-test
     strategy:
       matrix:
         component: ["standard", "pytorch", "pytorch-lightning"]
@@ -41,7 +35,6 @@ jobs:
 
   docker-dashboard:
     runs-on: ubuntu-latest
-    needs: integration-test
     steps:
       - uses: actions/checkout@v4
       - name: Login to Docker Hub

--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -1,25 +1,28 @@
 on:
-  workflow_call:
-    inputs:
-      test-flags:
-        default: "" # for the k8s test suite: "-m standard", "-m ddp" etc
-        required: false
-        type: string 
-      python-version:
-        default: "3.10" # "3.11"
-        required: false
-        type: string
-    secrets:
-      AWS_ACCESS_KEY_ID:
-        required: false
-      AWS_SECRET_ACCESS_KEY:
-        required: false
+  pull_request:
+    types:
+      - opened
+      - edited
+      - synchronize
+      - reopened
+    # Sequence of patterns matched against refs/heads
+    branches:
+      - master
+  push:
+    branches:
+      - master
 
 jobs:
-  integration-test:
+  integration-test-py310:
     uses: ./.github/workflows/test.yaml
     secrets: inherit
     with:
       test-suite: integration
-      test-flags: ${{ inputs.test-flags }}
-      python-version: ${{ inputs.python-version }}
+      python-version: "3.10"
+
+  integration-test-py311:
+    uses: ./.github/workflows/test.yaml
+    secrets: inherit
+    with:
+      test-suite: integration
+      python-version: "3.11"

--- a/.github/workflows/unit-test.yaml
+++ b/.github/workflows/unit-test.yaml
@@ -1,24 +1,28 @@
 on:
-  workflow_call:
-    inputs:
-      test-flags:
-        default: "" # for the k8s test suite: "-m standard", "-m ddp" etc
-        required: false
-        type: string 
-      python-version:
-        default: "3.10" # "3.11"
-        required: false
-        type: string
-    secrets:
-      AWS_ACCESS_KEY_ID:
-        required: false
-      AWS_SECRET_ACCESS_KEY:
-        required: false
+  pull_request:
+    types:
+      - opened
+      - edited
+      - synchronize
+      - reopened
+    # Sequence of patterns matched against refs/heads
+    branches:
+      - master
+  push:
+    branches:
+      - master
+
 jobs:
-  unit-test:
+  unit-test-py310:
     uses: ./.github/workflows/test.yaml
     secrets: inherit
     with:
       test-suite: unit
-      test-flags: ${{ inputs.test-flags }}
-      python-version: ${{ inputs.python-version }}
+      python-version: "3.10"
+
+  unit-test-py311:
+    uses: ./.github/workflows/test.yaml
+    secrets: inherit
+    with:
+      test-suite: unit
+      python-version: "3.11"

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Bettmensch.AI is a Kubernetes native open source platform for GitOps based ML workloads that allows for tight CI and CD integrations.
 
-![ci](https://github.com/SebastianScherer88/bettmensch.ai/actions/workflows/ci.yaml/badge.svg)
+![docker](https://github.com/SebastianScherer88/bettmensch.ai/actions/workflows/docker.yaml/badge.svg)
 ![unit tests](https://github.com/SebastianScherer88/bettmensch.ai/actions/workflows/unit-test.yaml/badge.svg)
 ![integration tests](https://github.com/SebastianScherer88/bettmensch.ai/actions/workflows/integration-test.yaml/badge.svg)
 ![k8s tests](https://github.com/SebastianScherer88/bettmensch.ai/actions/workflows/k8s-test.yaml/badge.svg)


### PR DESCRIPTION
converted the ci into 4 separate top level workflows & files:
- unit testing
- integration testing
- k8s testing (manual dispatch)
- docker images

so that the badges display correctly on the readme