### PR TITLE
fixed typoe in k8s make target

### DIFF
--- a/infrastructure/terraform/makefile
+++ b/infrastructure/terraform/makefile
@@ -21,7 +21,7 @@ platform.connect:
 	@echo "::group::Connecting to the platform..."
 	make kubernetes.configure
 	make kubernetes.connect
-	@echo "::endgroup::
+	@echo "::endgroup::"
 
 platform.test:
 	@echo "::group:: Running e2e platform tests"


### PR DESCRIPTION
The platform.connect make target had a typo that is breaking the k8s ci job