### PR TITLE
Add retries ci k8s

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -53,7 +53,12 @@ jobs:
 
       - name: Bring up platform
         if: ${{ inputs.test-suite == 'k8s' }}
-        run: make platform.up
+        # retry bc of https://github.com/SebastianScherer88/bettmensch.ai/actions/runs/11522285647/job/32077818521
+        uses: nick-fields/retry@v2
+        with:
+          timeout_minutes: 30
+          max_attempts: 2
+          command: make platform.up
         
       - name: Connect to platform
         if: ${{ inputs.test-suite == 'k8s' }}
@@ -74,5 +79,5 @@ jobs:
         run: make sdk.test SUITE="${{ inputs.test-suite }}" PYTEST_FLAGS="${{ inputs.test-flags }}"
 
       - name: Tear down platform (optional)
-        if: ${{ (success() || failure()) && (inputs.test-suite == 'k8s') && (inputs.deprovision-when-finished == 'true') }}
+        if: ${{ (always() && !cancelled()) && (inputs.test-suite == 'k8s') && (inputs.deprovision-when-finished == 'true') }}
         run: make platform.init && make platform.down

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -80,4 +80,8 @@ jobs:
 
       - name: Tear down platform (optional)
         if: ${{ (always() && !cancelled()) && (inputs.test-suite == 'k8s') && (inputs.deprovision-when-finished == 'true') }}
-        run: make platform.init && make platform.down
+        uses: nick-fields/retry@v2
+        with:
+          timeout_minutes: 30
+          max_attempts: 2
+          command: make platform.init && make platform.down


### PR DESCRIPTION
The provisioning of platform infra can sometimes take a couple of attempts, so adding retries to the CI step makes sense.

Same goes for the de-provisioning step to some extent