### PR TITLE
Cronjob platform tests

### DIFF
--- a/.github/workflows/manual-platform-test.yaml
+++ b/.github/workflows/manual-platform-test.yaml
@@ -25,6 +25,7 @@ on:
         default: false
         required: false
         type: boolean
+        
     secrets:
       AWS_ACCESS_KEY_ID:
         required: false

--- a/.github/workflows/platform-test.yaml
+++ b/.github/workflows/platform-test.yaml
@@ -1,0 +1,19 @@
+on:
+  schedule:
+    # run this test at 1am every other day
+    - cron: "00 01 */2 * *"
+    secrets:
+      AWS_ACCESS_KEY_ID:
+        required: false
+      AWS_SECRET_ACCESS_KEY:
+        required: false
+
+jobs:
+  k8s-test:
+    uses: ./.github/workflows/test.yaml
+    secrets: inherit
+    with:
+      test-suite: k8s
+      test-flags: ""
+      python-version: "3.10"
+      deprovision-when-finished: true

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -17,9 +17,9 @@ on:
         type: string
         description: The python version that the sdk will be installed with.
       deprovision-when-finished:
-        default: "false"
+        default: false
         required: false
-        type: string
+        type: boolean
         description: Whether to deprovision the platfrom after testing has finished, pass or fail. Only considered if the test suite is 'k8s'.
     secrets:
       AWS_ACCESS_KEY_ID:
@@ -79,7 +79,7 @@ jobs:
         run: make sdk.test SUITE="${{ inputs.test-suite }}" PYTEST_FLAGS="${{ inputs.test-flags }}"
 
       - name: Tear down platform (optional)
-        if: ${{ (always() && !cancelled()) && (inputs.test-suite == 'k8s') && (inputs.deprovision-when-finished == 'true') }}
+        if: ${{ (always() && !cancelled()) && (inputs.test-suite == 'k8s') && inputs.deprovision-when-finished }}
         uses: nick-fields/retry@v2
         with:
           timeout_minutes: 30

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Bettmensch.AI is a Kubernetes native open source platform for GitOps based ML wo
 ![docker](https://github.com/SebastianScherer88/bettmensch.ai/actions/workflows/docker.yaml/badge.svg)
 ![unit tests](https://github.com/SebastianScherer88/bettmensch.ai/actions/workflows/unit-test.yaml/badge.svg)
 ![integration tests](https://github.com/SebastianScherer88/bettmensch.ai/actions/workflows/integration-test.yaml/badge.svg)
-![k8s tests](https://github.com/SebastianScherer88/bettmensch.ai/actions/workflows/k8s-test.yaml/badge.svg)
+![platform tests](https://github.com/SebastianScherer88/bettmensch.ai/actions/workflows/platform-test.yaml/badge.svg)
 
 # Setup
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,7 @@
+[pytest]
+markers =
+    standard: marks standard pipeline test cases including parameters and artifacts. Components use the `standard` docker image.
+    ddp: marks the pytorch ddp pipeline test cases including the pytorch ddp and pytorch-lightning ddp code examples. Components use the `pytorch` and `pytorch-lightning` docker images.
+    delete_pipelines: marks the test case that removes all test pipelines and verifies removal.
+    delete_flows: marks the test case that removes all test flows and verifies removal.
+addopts = -vv -rfEs

--- a/sdk/makefile
+++ b/sdk/makefile
@@ -1,7 +1,7 @@
 ## VARIABLES
 EXTRAS?=pipelines# see sdk's setup.py for all options
 SUITE?=unit# unit,integration,k8s
-PYTEST_FLAGS?= # e.g. "-m standard", "-m ddp" for k8s suite
+PYTEST_FLAGS?= # e.g. "-m standard", "-m ddp" for k8s suite appended to the `addopts` setting of the pytest.ini
 sdk.install:
 	@echo "::group::Installing sdk with $(EXTRAS) extras"
 	pip install ./sdk[$(EXTRAS)]
@@ -10,5 +10,5 @@ sdk.install:
 sdk.test:
 	@echo "::group::Running sdk $(SUITE) test suite"
 	@echo "::group:: Commit: $(COMMIT)"
-	pytest ./sdk/test/$(SUITE)/ -vv -rfEs $(PYTEST_FLAGS)
+	pytest ./sdk/test/$(SUITE)/ $(PYTEST_FLAGS)
 	@echo "::endgroup::"


### PR DESCRIPTION
added platform test cronjob while retaining the manual one. converted the deprovisioning argument to boolean in underlying reusable test workflow.

also introduced pytest.ini to register markers, and also moved the verbose and reporting flags into the addopts field of the new .ini and out of the sdk make target