### PR TITLE
Fix ci platform test

### DIFF
--- a/.github/workflows/platform-test.yaml
+++ b/.github/workflows/platform-test.yaml
@@ -1,7 +1,7 @@
 name: Scheduled platform test
 on:
   schedule:
-    - cron: '0 1 * * *' # run this test at 1am every day
+    - cron: '50 16 * * *' # run this test at 16:40 UTC every day
 jobs:
   k8s-test:
     uses: ./.github/workflows/test.yaml

--- a/infrastructure/terraform/makefile
+++ b/infrastructure/terraform/makefile
@@ -1,5 +1,6 @@
 ## VARIABLES
 DIR?=infrastructure/terraform
+ARTIFACT_REPOSITORY_S3_BUCKET=bettmensch-ai-artifact-repository
 
 platform.init:
 	@echo "::group::Initializing platform infrastructure environment"
@@ -40,8 +41,10 @@ platform.delete_test_flows:
 
 platform.down:
 	@echo "::group::Tearing down platform infrastructure..."
-	# empty the argo workflow artifact repository s3 bucket, otherwise we
-	# wont be able to remove it from AWS
-	aws s3 rm s3://bettmensch-ai-artifact-repository --recursive
+	# if it exists, empty the argo workflow artifact repository s3 bucket, 
+	# otherwise we wont be able to remove it from AWS
+	python3 -c "import boto3;buckets=boto3.client('s3').list_buckets()['Buckets'];exists=len([b for b in buckets if b['Name']=='$(ARTIFACT_REPOSITORY_S3_BUCKET)'])==1;_ = boto3.resource('s3').Bucket('$(ARTIFACT_REPOSITORY_S3_BUCKET)').objects.all().delete() if exists else None"
+	
+	# tear down infra stack
 	terraform -chdir=$(DIR) destroy -auto-approve
 	@echo "::endgroup::"


### PR DESCRIPTION
Adding bucket existing checks to the bucket emptying step. That should fix the `platform.down` retry issues trying to empty a non existant bucket in the second attempt: 
![image](https://github.com/user-attachments/assets/4df82fbe-6433-47c1-89bf-0e97c898925e)
