### PR TITLE
Fix ci platform test part 2

### DIFF
--- a/.github/workflows/platform-test.yaml
+++ b/.github/workflows/platform-test.yaml
@@ -1,7 +1,7 @@
 name: Scheduled platform test
 on:
   schedule:
-    - cron: '50 16 * * *' # run this test at 16:40 UTC every day
+    - cron: '25 18 * * *' # run this test at 16:40 UTC every day
 jobs:
   k8s-test:
     uses: ./.github/workflows/test.yaml

--- a/infrastructure/terraform/makefile
+++ b/infrastructure/terraform/makefile
@@ -4,6 +4,8 @@ ARTIFACT_REPOSITORY_S3_BUCKET=bettmensch-ai-artifact-repository
 
 platform.init:
 	@echo "::group::Initializing platform infrastructure environment"
+	pip install boto3 # needed for python bucket emptying utility in 
+	# `platform.down` target
 	terraform -chdir=$(DIR) init
 		@echo "::endgroup::"
 


### PR DESCRIPTION
Adding in the boto3 dependency in the platform make targets to fix the import error in the CI's `platform.down` step