### PR TITLE
Reduce costs from EKS logging to cloudwatch

### DIFF
--- a/infrastructure/terraform/eks.tf
+++ b/infrastructure/terraform/eks.tf
@@ -69,6 +69,12 @@ module "eks" {
     }
   }
 
+  # try and reduce cloudwatch logging costs
+  create_cloudwatch_log_group = true
+  cloudwatch_log_group_class = "INFREQUENT_ACCESS"
+  cloudwatch_log_group_retention_in_days = 1
+  cluster_enabled_log_types = [] # "audit", "api", "authenticator"
+
   cluster_addons = {
     coredns = {}
     kube-proxy = {}


### PR DESCRIPTION
- set retention to 1 day, 
- make access infrequent and 
- stop logging altogether