### PR TITLE
Moving `bettmensch.ai` dashboard to K8s & adding mlflow dashboard to its `Models` tab

### DIFF
--- a/docker/dashboard/docker-compose.yaml
+++ b/docker/dashboard/docker-compose.yaml
@@ -12,16 +12,16 @@ services:
         BASE_IMAGE: python
         BASE_IMAGE_VERSION: 3.11
     ports:
-      - 8501:8501
+      - 8502:8502
     environment:
       mlflow_backend_host: "http://127.0.0.1:5000"
       argo_workflows_backend_host: "https://127.0.0.1:2746"
       argo_workflows_backend_verify_ssl: "false"
-    command: [streamlit, run, src/0_home.py, --server.port=8501, --server.address=0.0.0.0]
+    command: [streamlit, run, src/0_home.py, --server.port=8502, --server.address=0.0.0.0]
     network_mode: "host"
     image: bettmensch88/bettmensch.ai-dashboard:local
     healthcheck:
-      test: [CMD, curl, -f, http://dashboard:8501/_stcore/health]
+      test: [CMD, curl, -f, http://dashboard:8502/_stcore/health]
       interval: 10s
       retries: 5
       start_period: 5s

--- a/docker/dashboard/src/utils.py
+++ b/docker/dashboard/src/utils.py
@@ -15,7 +15,7 @@ class MlflowDisplaySettings(BaseSettings):
     width: int = 1200
     height: int = 1000
     scrolling: bool = True
-    host: str = "mlflow.svc.cluster.local:5000"
+    host: str = "http://mlflow-server.mlflow.svc.cluster.local:5000"
     starting_endpoint: str = "#/models"
 
     model_config = SettingsConfigDict(env_prefix="mlflow_backend_")

--- a/docker/dashboard/src/utils.py
+++ b/docker/dashboard/src/utils.py
@@ -15,7 +15,7 @@ class MlflowDisplaySettings(BaseSettings):
     width: int = 1200
     height: int = 1000
     scrolling: bool = True
-    host: str = "http://mlflow-server.mlflow.svc.cluster.local:5000"
+    host: str = "http://127.0.0.1:5000"
     starting_endpoint: str = "#/models"
 
     model_config = SettingsConfigDict(env_prefix="mlflow_backend_")

--- a/infrastructure/terraform/kubernetes.tf
+++ b/infrastructure/terraform/kubernetes.tf
@@ -315,3 +315,31 @@ resource "kubectl_manifest" "mlflow" {
       kubectl_manifest.mlflow_namespace
   ]
 }
+
+################################################################################
+# Bettmensch.ai dashboard
+################################################################################
+
+# argo namespace
+resource "kubectl_manifest" "bettmensch_ai_namespace" {
+  yaml_body = <<-YAML
+    apiVersion: v1
+    kind: Namespace
+    metadata:
+      name: bettmensch-ai
+  YAML
+}
+
+# bettmensch.ai dashboard installation
+data "kubectl_file_documents" "bettmensch_ai_dashboard" {
+    content = file("../../kubernetes/manifests/dashboard/dashboard-installation.yaml")
+}
+
+resource "kubectl_manifest" "bettmensch_ai_dashboard" {
+    for_each  = data.kubectl_file_documents.bettmensch_ai_dashboard.manifests
+    yaml_body = each.value
+
+    depends_on = [
+      kubectl_manifest.bettmensch_ai_namespace
+  ]
+}

--- a/kubernetes/makefile
+++ b/kubernetes/makefile
@@ -37,6 +37,6 @@ kubernetes.connect.dashboard:
 	@echo "::endgroup::"
 
 kubernetes.connect:
-	# make kubernetes.connect.mlflow
+	make kubernetes.connect.mlflow
 	make kubernetes.connect.argo
 	make kubernetes.connect.dashboard

--- a/kubernetes/makefile
+++ b/kubernetes/makefile
@@ -1,26 +1,42 @@
 ## VARIABLES
 REGION?=us-east-2
 CLUSTER_NAME?=bettmensch-ai
-ARGO_HEAD_POD=$(shell kubectl get pods --selector=app=argo-server -n argo -o custom-columns=POD:metadata.name --no-headers)
+ARGO_SERVICE?=argo-server
+ARGO_NAMESPACE?=argo
 ARGO_PORT?=2746
-MLFLOW_HEAD_POD=$(shell kubectl get pods --selector=app=mlflow-server -n mlflow -o custom-columns=POD:metadata.name --no-headers)
+MLFLOW_SERVICE?=mlflow-server
+MLFLOW_NAMESPACE=mlflow
 MLFLOW_PORT?=5000
+DASHBOARD_SERVICE?=bettmensch-ai-dashboard
+DASHBOARD_NAMESPACE?=bettmensch-ai
+DASHBOARD_PORT=8501
 
 kubernetes.configure:
 	@echo "::group::Configuring kubeconfig"
 	aws eks --region $(REGION) update-kubeconfig --name $(CLUSTER_NAME)
 	@echo "::endgroup::"
 
-kubernetes.connect.mlflow:
+kubernetes.connect_service:
 	@echo "::group::Port fowarding the Mlflow server on the K8s cluster"
-	kubectl -n mlflow port-forward $(MLFLOW_HEAD_POD) --address 0.0.0.0 $(MLFLOW_PORT):$(MLFLOW_PORT) > mlflow-port-forward.log & # background process
+	kubectl -n $(NAMESPACE) port-forward service/$(SERVICE) --address 0.0.0.0 $(PORT):$(PORT) > port-forward-$(SERVICE).log & # background process
 	@echo "::endgroup::"
 
 kubernetes.connect.argo:
-	@echo "::group::Port forwarding the ArgoWorkflows server to the K8s cluster"
-	kubectl -n argo port-forward $(ARGO_HEAD_POD) --address 0.0.0.0 $(ARGO_PORT):$(ARGO_PORT) > argo-port-forward.log & # background process
+	@echo "::group::Port fowarding the ArgoWorkflows server on the K8s cluster"
+	make kubernetes.connect_service NAMESPACE=$(ARGO_NAMESPACE) SERVICE=$(ARGO_SERVICE) PORT=$(ARGO_PORT)
+	@echo "::endgroup::"
+
+kubernetes.connect.mlflow:
+	@echo "::group::Port fowarding the Mlflow server on the K8s cluster"
+	make kubernetes.connect_service NAMESPACE=$(MLFLOW_NAMESPACE) SERVICE=$(MLFLOW_SERVICE) PORT=$(MLFLOW_PORT)
+	@echo "::endgroup::"
+
+kubernetes.connect.dashboard:
+	@echo "::group::Port fowarding the Bettmensch.ai dashboard on the K8s cluster"
+	make kubernetes.connect_service NAMESPACE=$(DASHBOARD_NAMESPACE) SERVICE=$(DASHBOARD_SERVICE) PORT=$(DASHBOARD_PORT)
 	@echo "::endgroup::"
 
 kubernetes.connect:
-	make kubernetes.connect.mlflow
+	# make kubernetes.connect.mlflow
 	make kubernetes.connect.argo
+	make kubernetes.connect.dashboard

--- a/kubernetes/manifests/dashboard/dashboard-installation.yaml
+++ b/kubernetes/manifests/dashboard/dashboard-installation.yaml
@@ -37,7 +37,7 @@ spec:
         - name: mlflow_backend_scrolling
           value: "True"
         - name: mlflow_backend_host
-          value: "http://mlflow-server.mlflow.svc.cluster.local:5000"
+          value: "http://127.0.0.1:5000"
         - name: mlflow_backend_starting_endpoint
           value: "#/models"
         # argo workflows server specs

--- a/kubernetes/manifests/dashboard/dashboard-installation.yaml
+++ b/kubernetes/manifests/dashboard/dashboard-installation.yaml
@@ -1,0 +1,60 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: bettmensch-ai-dashboard
+  namespace: bettmensch-ai
+spec:
+  ports:
+  - port: 8501
+    protocol: TCP
+    targetPort: streamlit
+  selector:
+    app: bettmensch-ai-dashboard
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: bettmensch-ai-dashboard
+  namespace: bettmensch-ai
+spec:
+  selector:
+    matchLabels:
+      app: bettmensch-ai-dashboard
+  template:
+    metadata:
+      labels:
+        app: bettmensch-ai-dashboard
+    spec:
+      containers:
+      - name: streamlit
+        command: ["streamlit", "run", "src/0_home.py", "--server.port=8501", "--server.address=0.0.0.0"]
+        env:
+        # mlflow dashboard specs
+        - name: mlflow_backend_width
+          value: "1200"
+        - name: mlflow_backend_height
+          value: "1000"
+        - name: mlflow_backend_scrolling
+          value: "True"
+        - name: mlflow_backend_host
+          value: "http://mlflow-server.mlflow.svc.cluster.local:5000"
+        - name: mlflow_backend_starting_endpoint
+          value: "#/models"
+        # argo workflows server specs
+        - name: argo_workflows_backend_namespace
+          value: "argo"
+        - name: argo_workflows_backend_host
+          value: "https://argo-server.argo.svc.cluster.local:2746"
+        - name: argo_workflows_backend_verify_ssl
+          value: "False"
+        image: bettmensch88/bettmensch.ai-dashboard:3.11-latest
+        imagePullPolicy: Always
+        livenessProbe:
+          httpGet:
+            path: /_stcore/health
+            port: 8501
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        ports:
+        - containerPort: 8501
+          name: streamlit

--- a/kubernetes/manifests/mlflow/mlflow-installation.yaml
+++ b/kubernetes/manifests/mlflow/mlflow-installation.yaml
@@ -22,15 +22,13 @@ metadata:
 apiVersion: v1
 kind: Service
 metadata:
-  labels:
-    app: mlflow-server
   name: mlflow-server
   namespace: mlflow
 spec:
   ports:
   - port: 5000
     protocol: TCP
-    targetPort: tracking-server
+    targetPort: 5000
   selector:
     app: mlflow-server
 ---


### PR DESCRIPTION
Adding a working deployment + service + namespace to host the `bettmensch.ai` dashboard on the K8s cluster.

Sadly, streamlit's `iframe` method us purely frontend, meaning that it cant be pointed to K8s cluster internal service DNS but only publically available websites or locally port forwarded addresses (in other words, URLs accessible to the browser run by the end user, which is outside the cluster)

Adding the MLflow dashboard to the bettmensch.ai streamlit dashboard therefore means retaining the mlflow dashboard servcice port forward and simply pointing towards `127.0.0.1:5000` on the end users machine. Only a temporary solution for now. 

A workaround could be exposing mlflow and bettmensch.ai dashboards via ingress and forcing the iframe to go via the internet to access the K8s service, but that seems less than ideal

Current `Models` tab in dashboard:

![image](https://github.com/user-attachments/assets/c3b13247-6235-4f87-b5ae-297a36963c72)
