### PR TITLE
Fix k8s service naming issue for ddp components

### DIFF
--- a/sdk/bettmensch_ai/components/base_component.py
+++ b/sdk/bettmensch_ai/components/base_component.py
@@ -30,7 +30,8 @@ class BaseComponent(object):
     name: str = None
     func: Callable = None
     base_name: str = None
-    name: str = None
+    name: str = None  # this attribute will hold the name of the ArgoWorkflow
+    # Task and the Template of this component
     hera_template_kwargs: Dict = {}
     template_inputs: Dict[str, Union[InputParameter, InputArtifact]] = None
     template_outputs: Dict[str, Union[OutputParameter, OutputArtifact]] = None

--- a/sdk/bettmensch_ai/components/torch_ddp_component.py
+++ b/sdk/bettmensch_ai/components/torch_ddp_component.py
@@ -86,10 +86,7 @@ class TorchDDPComponentInlineScriptRunner(BaseComponentInlineScriptRunner):
         # add function definition and decoration with `torch_ddp`
         torch_ddp_decoration = [
             "\nfrom bettmensch_ai.components import torch_ddp\n",
-            "component_task_name={{task.name}}\n"
-            "workflow_name={{workflow.name}}\n",
-            "svc_dns=f'{component_task_name}-{workflow_name}.argo.svc.cluster.local'\n"  # noqa: E501
-            "torch_ddp_decorator=torch_ddp(rdzv_endpoint_url=svc_dns)\n"
+            "torch_ddp_decorator=torch_ddp()\n",
             f"""torch_ddp_function=torch_ddp_decorator({
                 instance.source.__name__
             })\n""",
@@ -230,6 +227,10 @@ class TorchDDPComponent(BaseComponent):
             Env(
                 name=f"{LaunchConfigSettings.model_config['env_prefix']}rdzv_backend",  # noqa: E501
                 value="static",
+            ),
+            Env(
+                name=f"{LaunchConfigSettings.model_config['env_prefix']}rdzv_endpoint_url",  # noqa: E501
+                value=f"{self.name}-{{{{workflow.name}}}}.{self.k8s_namespace}.svc.cluster.local",  # noqa: E501
             ),
             Env(
                 name=f"{LaunchConfigSettings.model_config['env_prefix']}rdzv_endpoint_port",  # noqa: E501

--- a/sdk/bettmensch_ai/components/torch_ddp_component.py
+++ b/sdk/bettmensch_ai/components/torch_ddp_component.py
@@ -230,7 +230,7 @@ class TorchDDPComponent(BaseComponent):
             ),
             Env(
                 name=f"{LaunchConfigSettings.model_config['env_prefix']}rdzv_endpoint_url",  # noqa: E501
-                value=f"{self.name}-{{{{workflow.name}}}}.{self.k8s_namespace}.svc.cluster.local",  # noqa: E501
+                value=f"{self.name}-{{{{workflow.uid}}}}.{self.k8s_namespace}.svc.cluster.local",  # noqa: E501
             ),
             Env(
                 name=f"{LaunchConfigSettings.model_config['env_prefix']}rdzv_endpoint_port",  # noqa: E501

--- a/sdk/bettmensch_ai/components/torch_ddp_component.py
+++ b/sdk/bettmensch_ai/components/torch_ddp_component.py
@@ -2,7 +2,6 @@ import copy
 import inspect
 import textwrap
 from typing import Callable, Dict, List, Optional, Union
-from uuid import uuid4
 
 from bettmensch_ai.components.base_component import BaseComponent
 from bettmensch_ai.components.base_inline_script_runner import (
@@ -87,7 +86,10 @@ class TorchDDPComponentInlineScriptRunner(BaseComponentInlineScriptRunner):
         # add function definition and decoration with `torch_ddp`
         torch_ddp_decoration = [
             "\nfrom bettmensch_ai.components import torch_ddp\n",
-            "torch_ddp_decorator=torch_ddp()\n"
+            "component_task_name={{task.name}}\n"
+            "workflow_name={{workflow.name}}\n",
+            "svc_dns=f'{component_task_name}-{workflow_name}.argo.svc.cluster.local'\n"  # noqa: E501
+            "torch_ddp_decorator=torch_ddp(rdzv_endpoint_url=svc_dns)\n"
             f"""torch_ddp_function=torch_ddp_decorator({
                 instance.source.__name__
             })\n""",
@@ -120,7 +122,6 @@ class TorchDDPComponent(BaseComponent):
     nproc_per_node: int
     service_templates: Dict[str, Callable] = None
     k8s_namespace: str = ARGO_NAMESPACE
-    k8s_service_name: str = ""
 
     # if no resources are specified, set minimal requirements derived from
     # testing the ddp example on K8s
@@ -165,11 +166,11 @@ class TorchDDPComponent(BaseComponent):
         return {
             "create": create_torch_ddp_service_template(
                 component_base_name=self.base_name,
-                service_name=self.k8s_service_name,
+                component_task_name=self.name,
             ),
             "delete": delete_torch_ddp_service_template(
                 component_base_name=self.base_name,
-                service_name=self.k8s_service_name,
+                component_task_name=self.name,
             ),
         }
 
@@ -231,11 +232,6 @@ class TorchDDPComponent(BaseComponent):
                 value="static",
             ),
             Env(
-                name=f"{LaunchConfigSettings.model_config['env_prefix']}rdzv_endpoint_url",  # noqa: E501
-                value=f"{self.k8s_service_name}.{self.k8s_namespace}"
-                + ".svc.cluster.local",
-            ),
-            Env(
                 name=f"{LaunchConfigSettings.model_config['env_prefix']}rdzv_endpoint_port",  # noqa: E501
                 value=DDP_PORT_NUMBER,
             ),
@@ -255,7 +251,7 @@ class TorchDDPComponent(BaseComponent):
         labels.update(
             {
                 "torch-node": torch_node_rank,
-                "torch-job": self.k8s_service_name,
+                "torch-job": self.name,
             }
         )
         script_decorator_kwargs["labels"] = labels
@@ -272,8 +268,6 @@ class TorchDDPComponent(BaseComponent):
                 active hera DAG context, generate the hera Tasks, one for each
                 node in the distributed torch run.
         """
-
-        self.k8s_service_name = f"{self.name}-{uuid4()}"
 
         # add torch run environment variables to script kwargs
         task_factory = []

--- a/sdk/bettmensch_ai/components/torch_utils.py
+++ b/sdk/bettmensch_ai/components/torch_utils.py
@@ -140,7 +140,7 @@ def torch_ddp(**config_settings_kwargs):
 
 def create_torch_ddp_service_template(
     component_base_name: str,
-    service_name: str,
+    component_task_name: str,
     namespace: str = ARGO_NAMESPACE,  # noqa: E501
 ) -> Resource:
     """Utility for a template creating the service resource required for
@@ -152,10 +152,8 @@ def create_torch_ddp_service_template(
         manifest=f"""apiVersion: v1
 kind: Service
 metadata:
-  name: {service_name}
+  name: {component_task_name}-{{workflow.name}}
   namespace: {namespace}
-  labels:
-    app: {service_name}
 spec:
   clusterIP: None  # ClusterIP set to None for headless service.
   ports:
@@ -163,7 +161,8 @@ spec:
     port: {DDP_PORT_NUMBER}
     targetPort: {DDP_PORT_NUMBER}
   selector:
-    torch-job: {service_name}
+    workflows.argoproj.io/workflow: {{workflow.name}}
+    torch-job: {component_task_name}
     torch-node: '0'  # Selector for pods associated with this service.
 """,
     )
@@ -171,7 +170,7 @@ spec:
 
 def delete_torch_ddp_service_template(
     component_base_name: str,
-    service_name: str,
+    component_task_name: str,
     namespace: str = ARGO_NAMESPACE,  # noqa: E501
 ) -> Resource:
     """Utility for a template deleting the service resource required for
@@ -182,9 +181,7 @@ def delete_torch_ddp_service_template(
         action="delete",
         flags=[
             "service",
-            "--selector",
-            f"app={service_name}",
-            "-n",
+            component_task_name + "-{{workflow.name}}" "-n",
             namespace,
         ],
     )

--- a/sdk/bettmensch_ai/components/torch_utils.py
+++ b/sdk/bettmensch_ai/components/torch_utils.py
@@ -152,7 +152,7 @@ def create_torch_ddp_service_template(
         manifest=f"""apiVersion: v1
 kind: Service
 metadata:
-  name: {component_task_name}-{{workflow.name}}
+  name: {component_task_name}-{{{{workflow.name}}}}
   namespace: {namespace}
 spec:
   clusterIP: None  # ClusterIP set to None for headless service.
@@ -161,7 +161,7 @@ spec:
     port: {DDP_PORT_NUMBER}
     targetPort: {DDP_PORT_NUMBER}
   selector:
-    workflows.argoproj.io/workflow: {{workflow.name}}
+    workflows.argoproj.io/workflow: {{{{workflow.name}}}}
     torch-job: {component_task_name}
     torch-node: '0'  # Selector for pods associated with this service.
 """,
@@ -181,7 +181,9 @@ def delete_torch_ddp_service_template(
         action="delete",
         flags=[
             "service",
-            component_task_name + "-{{workflow.name}}" "-n",
+            "--selector",
+            f"torch-job={component_task_name},workflows.argoproj.io/workflow={{{{workflow.name}}}}",  # noqa: E501
+            "-n",
             namespace,
         ],
     )

--- a/sdk/bettmensch_ai/components/torch_utils.py
+++ b/sdk/bettmensch_ai/components/torch_utils.py
@@ -152,8 +152,11 @@ def create_torch_ddp_service_template(
         manifest=f"""apiVersion: v1
 kind: Service
 metadata:
-  name: {component_task_name}-{{{{workflow.name}}}}
+  name: {component_task_name}-{{{{workflow.uid}}}}
   namespace: {namespace}
+  labels:
+    workflows.argoproj.io/workflow: {{{{workflow.name}}}}
+    torch-job: {component_task_name}
 spec:
   clusterIP: None  # ClusterIP set to None for headless service.
   ports:

--- a/sdk/test/unit/test_pipeline.py
+++ b/sdk/test/unit/test_pipeline.py
@@ -74,11 +74,7 @@ def test_artifact_pipeline(
     ]
 
     assert wft.templates[3].labels["torch-node"] == "0"
-    assert (
-        wft.templates[3]
-        .labels["torch-job"]
-        .startswith("convert-to-artifact-0-")
-    )
+    assert wft.templates[3].labels["torch-job"] == "convert-to-artifact-0"
     assert wft.templates[4].labels["torch-node"] == "1"
 
     parameter_to_artifact.export(test_output_dir)
@@ -146,7 +142,7 @@ def test_parameter_pipeline(test_output_dir):
     ]
 
     assert wft.templates[3].labels["torch-node"] == "0"
-    assert wft.templates[3].labels["torch-job"].startswith("a-plus-b-0-")
+    assert wft.templates[3].labels["torch-job"] == "a-plus-b-0"
     assert wft.templates[4].labels["torch-node"] == "1"
 
     adding_parameters.export(test_output_dir)

--- a/sdk/test/unit/test_torch_ddp_component.py
+++ b/sdk/test/unit/test_torch_ddp_component.py
@@ -212,7 +212,9 @@ def test_torch_component_decorator(test_mock_pipeline, test_mock_component):
     assert test_component.task_factory is None
 
 
-def test_parameter_torch_component_to_hera(test_mock_pipeline):
+def test_parameter_torch_component_to_hera(
+    test_output_dir, test_mock_pipeline
+):
     """Declaration of Component using InputParameter and OutputParameter"""
 
     # mock active pipeline with 2 inputs
@@ -255,7 +257,7 @@ def test_parameter_torch_component_to_hera(test_mock_pipeline):
     a_plus_b_plus_2.task_factory = a_plus_b_plus_2.build_hera_task_factory()
 
     with WorkflowTemplate(
-        name="test-parameter-component-workflow-template",
+        name="test-parameter-torch-ddp-component-workflow-template",
         entrypoint="test_dag",
         namespace="argo",
         arguments=[
@@ -272,6 +274,8 @@ def test_parameter_torch_component_to_hera(test_mock_pipeline):
         with DAG(name="test_dag"):
             a_plus_b.to_hera()
             a_plus_b_plus_2.to_hera()
+
+    wft.to_file(test_output_dir)
 
     task_names = [task.name for task in wft.templates[4].tasks]
     assert task_names == [
@@ -310,6 +314,7 @@ def test_parameter_torch_component_to_hera(test_mock_pipeline):
 
 
 def test_artifact_torch_component_to_hera(
+    test_output_dir,
     test_mock_pipeline,
 ):
 
@@ -346,7 +351,7 @@ def test_artifact_torch_component_to_hera(
     show.task_factory = show.build_hera_task_factory()
 
     with WorkflowTemplate(
-        name="test-artifact-component-workflow-template",
+        name="test-artifact-torch-ddp-component-workflow-template",
         entrypoint="test_dag",
         namespace="argo",
         arguments=[
@@ -360,6 +365,8 @@ def test_artifact_torch_component_to_hera(
         with DAG(name="test_dag"):
             convert.to_hera()
             show.to_hera()
+
+    wft.to_file(test_output_dir)
 
     task_names = [task.name for task in wft.templates[4].tasks]
     assert task_names == [

--- a/sdk/test/unit/test_torch_ddp_component.py
+++ b/sdk/test/unit/test_torch_ddp_component.py
@@ -303,12 +303,12 @@ def test_parameter_torch_component_to_hera(
     ]
 
     assert wft.templates[5].labels["torch-node"] == "0"
-    assert wft.templates[5].labels["torch-job"].startswith("a-plus-b-0-")
+    assert wft.templates[5].labels["torch-job"] == "a-plus-b-0"
     assert wft.templates[6].labels["torch-node"] == "1"
 
     assert wft.templates[7].labels["torch-node"] == "0"
     assert (
-        wft.templates[7].labels["torch-job"].startswith("a-plus-b-plus-2-0-")
+        wft.templates[7].labels["torch-job"] == "a-plus-b-plus-2-0"
     )  # noqa: E501
     assert wft.templates[8].labels["torch-node"] == "1"
 
@@ -393,11 +393,10 @@ def test_artifact_torch_component_to_hera(
 
     assert wft.templates[5].labels["torch-node"] == "0"
     assert (
-        wft.templates[5]
-        .labels["torch-job"]
-        .startswith("convert-parameters-0-")  # noqa: E501
+        wft.templates[5].labels["torch-job"]
+        == "convert-parameters-0"  # noqa: E501
     )
     assert wft.templates[6].labels["torch-node"] == "1"
 
     assert wft.templates[7].labels["torch-node"] == "0"
-    assert wft.templates[7].labels["torch-job"].startswith("show-artifacts-0-")
+    assert wft.templates[7].labels["torch-job"] == "show-artifacts-0"


### PR DESCRIPTION
Fixes: https://github.com/SebastianScherer88/bettmensch.ai/issues/14

Adding the argo workflow name/uid to the utility service resource name spec. this means that the service resource is now unique
- across all workflows (i.e. `Flow` = reruns of the same `Pipeline`)
- across all ddp components within a pipeline/flow (this was already the cases)

This means we can now safely run the same pipeline containing at least one ddp component in parallel, as the k8s service resources created during these runs will no longer conflict; neither in name, nor in the pods that they route to. 