### PR TITLE
Improve pipeline and flow queries

### DIFF
--- a/sdk/bettmensch_ai/constants.py
+++ b/sdk/bettmensch_ai/constants.py
@@ -54,12 +54,16 @@ class COMPONENT_IMPLEMENTATION(Enum):
 
 
 class FLOW_LABEL(Enum):
+    """A utility class for valid Flow label keys"""
+
     pipeline_name: str = "bettmensch.ai/pipeline-name"
     pipeline_id: str = "bettmensch.ai/pipeline-id"
     phase: str = "workflows.argoproj.io/phase"
 
 
 class FLOW_PHASE(Enum):
+    """A utility class for valid Flow phase label values"""
+
     pending: str = "Pending"
     running: str = "Running"
     succeeded: str = "Succeeded"

--- a/sdk/bettmensch_ai/constants.py
+++ b/sdk/bettmensch_ai/constants.py
@@ -51,3 +51,12 @@ class COMPONENT_IMPLEMENTATION(Enum):
     base: str = "base"
     standard: str = "standard"
     torch_ddp: str = "torch-ddp"
+
+
+class FLOW_PHASE(Enum):
+    pending: str = "Pending"
+    running: str = "Running"
+    succeeded: str = "Succeeded"
+    failed: str = "Failed"
+    error: str = "Error"
+    unknown: str = ""

--- a/sdk/bettmensch_ai/constants.py
+++ b/sdk/bettmensch_ai/constants.py
@@ -53,6 +53,11 @@ class COMPONENT_IMPLEMENTATION(Enum):
     torch_ddp: str = "torch-ddp"
 
 
+class FLOW_LABEL(Enum):
+    pipeline_name: str = "bettmensch.ai/pipeline-name"
+    pipeline_id: str = "bettmensch.ai/pipeline-id"
+
+
 class FLOW_PHASE(Enum):
     pending: str = "Pending"
     running: str = "Running"

--- a/sdk/bettmensch_ai/constants.py
+++ b/sdk/bettmensch_ai/constants.py
@@ -56,6 +56,7 @@ class COMPONENT_IMPLEMENTATION(Enum):
 class FLOW_LABEL(Enum):
     pipeline_name: str = "bettmensch.ai/pipeline-name"
     pipeline_id: str = "bettmensch.ai/pipeline-id"
+    phase: str = "workflows.argoproj.io/phase"
 
 
 class FLOW_PHASE(Enum):

--- a/sdk/bettmensch_ai/pipelines/flow.py
+++ b/sdk/bettmensch_ai/pipelines/flow.py
@@ -1,5 +1,6 @@
-from typing import List, Optional
+from typing import Dict, List, Optional
 
+from bettmensch_ai.constants import ARGO_NAMESPACE, FLOW_PHASE
 from bettmensch_ai.pipelines.client import hera_client
 from hera.workflows import Workflow
 from hera.workflows.models import Workflow as WorkflowModel
@@ -18,7 +19,58 @@ class Flow(object):
 
     @property
     def registered_name(self) -> str:
+        """The unique name of the flow (= argo Workflow)
+
+        Returns:
+            str: The name of the flow
+        """
         return self.registered_flow.name
+
+    @property
+    def pipeline(self) -> str:
+        """The unique name of the pipeline (= argo WorkflowTemplate) that the
+            flow originates from.
+
+        Returns:
+            str: The name of the parent pipeline
+        """
+        return self.registered_flow.workflow_template_ref.name
+
+    @property
+    def phase(self) -> str:
+        """The current phase of the flow (= argo Workflow)
+
+        Returns:
+            str: The phase of the flow
+        """
+
+        return self.registered_flow.status.phase
+
+    @property
+    def started_at(self) -> str:
+        """The time the flow started (where applicable). Returns None if not
+        started yet.
+
+        E.g. "2024-11-05T13:04:19Z"
+
+        Returns:
+            str: The phase of the flow
+        """
+
+        return self.registered_flow.status.started_at
+
+    @property
+    def finished_at(self) -> str:
+        """The time the flow finished (where applicable). Returns None if not
+        finished yet.
+
+        E.g. "2024-11-05T13:04:19Z"
+
+        Returns:
+            str: The phase of the flow
+        """
+
+        return self.registered_flow.status.finished_at
 
     @classmethod
     def from_workflow(cls, workflow: Workflow) -> "Flow":
@@ -36,7 +88,7 @@ class Flow(object):
 
 
 def get_flow(
-    registered_name: str, registered_namespace: Optional[str] = None
+    registered_name: str, registered_namespace: str = ARGO_NAMESPACE
 ) -> Flow:
     """Returns the specified Flow.
 
@@ -61,16 +113,61 @@ def get_flow(
 
 
 def list_flows(
-    registered_namespace: Optional[str] = None,
-    label_selector: Optional[str] = None,
-    field_selector: Optional[str] = None,
+    registered_namespace: str = ARGO_NAMESPACE,
+    pipeline: Optional[str] = None,
+    phase: Optional[str] = None,
+    labels: Dict = {},
     **kwargs,
 ) -> List[Flow]:
-    """Lists all flows.
+    """List[Flow]: A list of all Flows that meet the query scope.
+
+    Args:
+        registered_namespace (Optional[str], optional): The name in which the
+            underlying argo Workflow lives. Defaults to ARGO_NAMESPACE.
+        pipeline (Optional[str], optional): Optional filter to only consider
+            Flows that originate from the specified pipeline. Defaults to None,
+            i.e. no pipeline-based filtering.
+        phase (Optional[str], optional): Optional filter to only consider Flows
+            that are in the specified phase. Defaults to None, i.e. no phase-
+            based filtering.
+        labels (Dict, optional): Optional filter to only consider Flows whose
+            underlying argo Workflow resource contains all of the specified
+            labels. Defaults to {}, i.e. no label-based filtering.
 
     Returns:
-        List[Flow]: A list of all Flows that meet the query scope.
+        List[Flow]: A list of Flows that meet the filtering specifications.
     """
+
+    # build field selector
+    if pipeline is None and phase is None:
+        field_selector = None
+    else:
+        field_selectors = []
+
+        if pipeline is not None:
+            field_selectors.append(f"spec.workflowTemplateRef.name={pipeline}")
+
+        if phase is not None:
+            assert phase in (
+                FLOW_PHASE.error,
+                FLOW_PHASE.failed,
+                FLOW_PHASE.pending,
+                FLOW_PHASE.running,
+                FLOW_PHASE.succeeded,
+                FLOW_PHASE.unknown,
+            ), f"Invalid phase spec: {phase}. Must be one of the constants.FLOW_PHASE levels."  # noqa: E501
+            field_selectors.append(f"status.phase={phase}")
+
+        field_selector = ",".join(field_selectors)
+
+    # build label selector
+    if labels is not None:
+        label_selector = None
+    else:
+        kv_label_list = list(labels.items())  # [('a',1),('b',2)]
+        label_selector = ",".join(
+            [f"{k}={v}" for k, v in kv_label_list]
+        )  # "a=1,b=2"
 
     response = hera_client.list_workflows(
         namespace=registered_namespace,
@@ -95,7 +192,7 @@ def list_flows(
 
 
 def delete_flow(
-    registered_name: str, registered_namespace: Optional[str] = None, **kwargs
+    registered_name: str, registered_namespace: str = ARGO_NAMESPACE, **kwargs
 ) -> WorkflowDeleteResponseModel:
     """Deletes the specified Flow from the server.
 

--- a/sdk/bettmensch_ai/pipelines/flow.py
+++ b/sdk/bettmensch_ai/pipelines/flow.py
@@ -19,29 +19,39 @@ class Flow(object):
 
     @property
     def registered_name(self) -> str:
-        """The unique name of the flow (= argo Workflow)
+        """The unique name of the Flow (= argo Workflow)
 
         Returns:
-            str: The name of the flow
+            str: The name of the Flow
         """
         return self.registered_flow.name
 
     @property
-    def pipeline(self) -> str:
-        """The unique name of the pipeline (= argo WorkflowTemplate) that the
-            flow originates from.
+    def registered_namespace(self) -> str:
+        """The namespace of the Flow (= argo Workflow)
 
         Returns:
-            str: The name of the parent pipeline
+            str: The namespace of the Flow
+        """
+
+        return self.registered_flow.namespace
+
+    @property
+    def pipeline(self) -> str:
+        """The unique name of the pipeline (= argo WorkflowTemplate) that the
+            Flow originates from.
+
+        Returns:
+            str: The name of the parent Pipeline
         """
         return self.registered_flow.workflow_template_ref.name
 
     @property
     def phase(self) -> str:
-        """The current phase of the flow (= argo Workflow)
+        """The current phase of the Flow (= argo Workflow)
 
         Returns:
-            str: The phase of the flow
+            str: The phase of the Flow
         """
 
         return self.registered_flow.status.phase
@@ -122,8 +132,8 @@ def list_flows(
     """List[Flow]: A list of all Flows that meet the query scope.
 
     Args:
-        registered_namespace (Optional[str], optional): The name in which the
-            underlying argo Workflow lives. Defaults to ARGO_NAMESPACE.
+        registered_namespace (Optional[str], optional): The namespace in which
+            the underlying argo Workflow lives. Defaults to ARGO_NAMESPACE.
         pipeline (Optional[str], optional): Optional filter to only consider
             Flows that originate from the specified pipeline. Defaults to None,
             i.e. no pipeline-based filtering.

--- a/sdk/bettmensch_ai/pipelines/flow.py
+++ b/sdk/bettmensch_ai/pipelines/flow.py
@@ -134,6 +134,9 @@ def list_flows(
     Args:
         registered_namespace (Optional[str], optional): The namespace in which
             the underlying argo Workflow lives. Defaults to ARGO_NAMESPACE.
+        registered_pipeline_name (Optional[str], optional): Optional filter to
+            only consider Flows originating from the specified registered
+            Pipeline. Defaults to None, i.e. no pipeline-based filtering.
         phase (Optional[str], optional): Optional filter to only consider Flows
             that are in the specified phase. Defaults to None, i.e. no phase-
             based filtering.

--- a/sdk/bettmensch_ai/pipelines/flow.py
+++ b/sdk/bettmensch_ai/pipelines/flow.py
@@ -124,19 +124,19 @@ def get_flow(
 
 def list_flows(
     registered_namespace: str = ARGO_NAMESPACE,
-    pipeline: Optional[str] = None,
+    registered_pipeline_name: Optional[str] = None,
     phase: Optional[str] = None,
     labels: Dict = {},
     **kwargs,
 ) -> List[Flow]:
-    """List[Flow]: A list of all Flows that meet the query scope.
+    """Get all flows that meet the query specifications.
 
     Args:
         registered_namespace (Optional[str], optional): The namespace in which
             the underlying argo Workflow lives. Defaults to ARGO_NAMESPACE.
-        pipeline (Optional[str], optional): Optional filter to only consider
-            Flows that originate from the specified pipeline. Defaults to None,
-            i.e. no pipeline-based filtering.
+        registered_pipeline_name (Optional[str], optional): Optional filter to
+            only consider Flows that originate from the specified pipeline.
+            Defaults to None, i.e. no pipeline-based filtering.
         phase (Optional[str], optional): Optional filter to only consider Flows
             that are in the specified phase. Defaults to None, i.e. no phase-
             based filtering.
@@ -149,13 +149,15 @@ def list_flows(
     """
 
     # build field selector
-    if pipeline is None and phase is None:
+    if registered_pipeline_name is None and phase is None:
         field_selector = None
     else:
         field_selectors = []
 
-        if pipeline is not None:
-            field_selectors.append(f"spec.workflowTemplateRef.name={pipeline}")
+        if registered_pipeline_name is not None:
+            field_selectors.append(
+                f"spec.workflowTemplateRef.name={registered_pipeline_name}"
+            )
 
         if phase is not None:
             assert phase in (

--- a/sdk/bettmensch_ai/pipelines/pipeline.py
+++ b/sdk/bettmensch_ai/pipelines/pipeline.py
@@ -437,7 +437,7 @@ class Pipeline(object):
         Args:
             phase (Optional[str], optional): Optional filter to only consider
                 Flows that are in the specified phase. Defaults to None, i.e.
-                no phase-based filtering.
+                no phase-based filtering. This will be added to the labels.
             additional_labels (Dict, optional): Optional filter to only
                 consider Flows whose underlying argo Workflow resource contains
                 all of the specified labels. Defaults to {}, i.e. no
@@ -455,16 +455,9 @@ class Pipeline(object):
                 "ran `register`?"
             )
 
-        # add pipeline name & id labels
-        additional_labels.update(
-            {
-                FLOW_LABEL.pipeline_name.value: self.registered_name,
-                FLOW_LABEL.pipeline_id.value: self.registered_id,
-            }
-        )
-
         return list_flows(
             registered_namespace=self.registered_namespace,
+            registered_pipeline_name=self.registered_name,
             phase=phase,
             labels=additional_labels,
             **kwargs,

--- a/sdk/test/k8s/test_flow.py
+++ b/sdk/test/k8s/test_flow.py
@@ -3,6 +3,7 @@ from bettmensch_ai.pipelines import Flow, delete_flow, get_flow, list_flows
 
 
 @pytest.mark.standard
+@pytest.mark.ddp
 @pytest.mark.order(10)
 def test_get_standard_flow(test_namespace):
     flows = list_flows(registered_namespace=test_namespace)

--- a/sdk/test/k8s/test_flow.py
+++ b/sdk/test/k8s/test_flow.py
@@ -1,11 +1,24 @@
 import pytest
-from bettmensch_ai.pipelines import delete_flow, list_flows
+from bettmensch_ai.pipelines import Flow, delete_flow, get_flow, list_flows
+
+
+@pytest.mark.standard
+@pytest.mark.order(10)
+def test_get_standard_flow(test_namespace):
+    flows = list_flows(registered_namespace=test_namespace)
+
+    for flow in flows:
+        flow_reloaded = get_flow(
+            registered_name=flow.registered_name,
+            registered_namespace=test_namespace,
+        )
+        assert isinstance(flow_reloaded, Flow)
 
 
 @pytest.mark.standard
 @pytest.mark.ddp
 @pytest.mark.delete_flows
-@pytest.mark.order(10)
+@pytest.mark.order(11)
 def test_delete(test_namespace):
     """Test the delete_flow function"""
 

--- a/sdk/test/k8s/test_pipeline.py
+++ b/sdk/test/k8s/test_pipeline.py
@@ -169,10 +169,11 @@ def test_list_flows_of_registered_standard_pipelines(
     for flow in flows:
         assert isinstance(flow, Flow)
         assert flow.registered_namespace == test_namespace
-        assert flow.phase == test_phase
         assert flow.registered_pipeline == registered_pipeline.registered_name
         assert flow.started_at is not None
         assert flow.finished_at is not None
+        if test_phase is not None:
+            assert flow.phase == test_phase
 
 
 @pytest.mark.standard

--- a/sdk/test/k8s/test_pipeline.py
+++ b/sdk/test/k8s/test_pipeline.py
@@ -7,6 +7,8 @@ from bettmensch_ai.components.examples import (
 from bettmensch_ai.constants import COMPONENT_IMAGE
 from bettmensch_ai.io import InputParameter
 from bettmensch_ai.pipelines import (
+    Flow,
+    Pipeline,
     delete_registered_pipeline,
     get_registered_pipeline,
     list_registered_pipelines,
@@ -88,27 +90,38 @@ def test_parameter_pipeline_decorator_and_register_and_run(
 @pytest.mark.standard
 @pytest.mark.order(3)
 @pytest.mark.parametrize(
-    "test_registered_pipeline_name_pattern,test_n_registered_pipelines",
+    "test_registered_pipeline_name_pattern,test_labels,test_n_registered_pipelines",  # noqa: E501
     [
-        ("test-artifact-pipeline-", 1),
-        ("test-parameter-pipeline-", 1),
-        ("test-", 2),
+        ("test-artifact-pipeline-", {}, 1),
+        (
+            "test-artifact-pipeline-",
+            {
+                "workflows.argoproj.io/creator": "system-serviceaccount-argo-argo-server"  # noqa: E501
+            },
+            1,
+        ),
+        ("test-artifact-pipeline-", {"invalid-label": "test"}, 0),
+        ("test-parameter-pipeline-", {}, 1),
+        ("test-", {}, 2),
     ],
 )
 def test_list_registered_standard_pipelines(
     test_namespace,
     test_registered_pipeline_name_pattern,
+    test_labels,
     test_n_registered_pipelines,
 ):
     """Test the pipeline.list function."""
     registered_pipelines = list_registered_pipelines(
         registered_namespace=test_namespace,
         registered_name_pattern=test_registered_pipeline_name_pattern,
+        labels=test_labels,
     )
 
     assert len(registered_pipelines) == test_n_registered_pipelines
 
     for registered_pipeline in registered_pipelines:
+        assert isinstance(registered_pipeline, Pipeline)
         assert registered_pipeline.registered
         assert registered_pipeline.registered_id is not None
         assert registered_pipeline.registered_name.startswith(
@@ -119,6 +132,51 @@ def test_list_registered_standard_pipelines(
 
 @pytest.mark.standard
 @pytest.mark.order(4)
+@pytest.mark.parametrize(
+    "test_registered_pipeline_name_pattern,test_phase,test_labels,test_n_flows",  # noqa: E501
+    [
+        ("test-artifact-pipeline-", None, {}, 1),
+        (
+            "test-artifact-pipeline-",
+            None,
+            {"workflows.argoproj.io/completed": "true"},
+            1,
+        ),
+        ("test-artifact-pipeline-", "Succeeded", {}, 1),
+        ("test-artifact-pipeline-", None, {"invalid-label": "test"}, 0),
+        ("test-artifact-pipeline-", "Failed", {}, 0),
+        ("test-parameter-pipeline-", None, {}, 1),
+    ],
+)
+def test_list_flows_of_registered_standard_pipelines(
+    test_namespace,
+    test_registered_pipeline_name_pattern,
+    test_phase,
+    test_labels,
+    test_n_flows,
+):
+    """Test the pipeline.list function."""
+    registered_pipeline = list_registered_pipelines(
+        registered_namespace=test_namespace,
+        registered_name_pattern=test_registered_pipeline_name_pattern,
+    )[0]
+
+    flows = registered_pipeline.list_flows(
+        phase=test_phase, additional_labels=test_labels
+    )
+
+    assert len(flows) == test_n_flows
+    for flow in flows:
+        assert isinstance(flow, Flow)
+        assert flow.registered_namespace == test_namespace
+        assert flow.phase == test_phase
+        assert flow.registered_pipeline == registered_pipeline.registered_name
+        assert flow.started_at is not None
+        assert flow.finished_at is not None
+
+
+@pytest.mark.standard
+@pytest.mark.order(5)
 @pytest.mark.parametrize(
     "test_registered_pipeline_name_pattern,test_pipeline_inputs",
     [
@@ -160,7 +218,7 @@ def test_run_standard_registered_pipelines_from_registry(
 
 
 @pytest.mark.ddp
-@pytest.mark.order(5)
+@pytest.mark.order(6)
 @pytest.mark.parametrize(
     "test_pipeline_name, test_n_nodes, test_gpus, test_memory",
     [
@@ -233,7 +291,7 @@ def test_torch_ddp_pipeline_decorator_and_register_and_run(
 
 
 @pytest.mark.ddp
-@pytest.mark.order(6)
+@pytest.mark.order(7)
 @pytest.mark.parametrize(
     "test_pipeline_name, test_n_nodes, test_gpus, test_memory",
     [
@@ -306,7 +364,7 @@ def test_lightning_ddp_pipeline_decorator_and_register_and_run(
 
 
 @pytest.mark.ddp
-@pytest.mark.order(7)
+@pytest.mark.order(8)
 @pytest.mark.parametrize(
     "test_registered_pipeline_name_pattern,test_n_registered_pipelines",
     [
@@ -339,7 +397,7 @@ def test_list_registered_ddp_pipelines(
 
 
 @pytest.mark.ddp
-@pytest.mark.order(8)
+@pytest.mark.order(9)
 @pytest.mark.parametrize(
     "test_registered_pipeline_name_pattern,test_pipeline_inputs",
     [
@@ -390,7 +448,7 @@ def test_run_dpp_registered_pipelines_from_registry(
 @pytest.mark.standard
 @pytest.mark.ddp
 @pytest.mark.delete_pipelines
-@pytest.mark.order(9)
+@pytest.mark.order(12)
 def test_delete_registered_pipeline(test_namespace):
     """Test the delete_registered_pipeline function"""
 


### PR DESCRIPTION
Improve the query functions and class methods in the `pipelines.flow` and `pipelines.pipeline` modules:

`pipeline`:
- `Pipeline` automatically attaches labels containing the registered pipeline's name and id to the  `Workflow` resource in its `run` method. This will allow us to list all `Flow`s associated to a given `Pipeline` by using the new `labels` filter in the `list_flow` function (see `flows` section below)
- `Pipeline` has new utility method `list_flows` to query flows associated with itself, also supporting filtering on `phase` value and additional `Workflow` resource `labels`

`flow`:
- `list_flows` allows to filter on the `Workflow` resource `labels` field, the original `Pipeline`'s `registered_name` attribute and the `Workflow`'s `phase` label value in a more straightforward way
- added `started_at`, `finished_at`, `pipeline`, `phase` properties to `Flow` class

Also updated the k8s tests to validate all the above