### PR TITLE
Fix karpenter configuration

### DIFF
--- a/kubernetes/manifests/karpenter/karpenter-nodepool.yaml
+++ b/kubernetes/manifests/karpenter/karpenter-nodepool.yaml
@@ -1,7 +1,7 @@
 apiVersion: karpenter.sh/v1beta1
 kind: NodePool
 metadata:
-  name: default-cpu
+  name: on-demand-cpu
 spec:
   template:
     spec:
@@ -22,18 +22,19 @@ spec:
           values: ["2"]
         - key: karpenter.sh/capacity-type
           operator: In
-          values: ["spot", "on-demand"]
+          values: ["on-demand"]
   limits:
     cpu: 100
     memory: 1000Gi
   disruption:
-    consolidationPolicy: WhenUnderutilized
-    expireAfter: 30m # ~5 minutes required for larger images, otherwise karpenter will deprovision before pods are running
+    consolidationPolicy: WhenUnderutilized | WhenEmpty
+    consolidateAfter: 15m # ~5 minutes required for larger images, otherwise karpenter will deprovision before pods are running
+    expireAfter: 24h
 ---
 apiVersion: karpenter.sh/v1beta1
 kind: NodePool
 metadata:
-  name: default-gpu
+  name: on-demand-gpu
 spec:
   template:
     spec:
@@ -48,7 +49,7 @@ spec:
           values: ["2"]
         - key: karpenter.sh/capacity-type
           operator: In
-          values: ["spot","on-demand"]
+          values: ["on-demand"]
       taints:
         - key: nvidia.com/gpu
           value: "true"
@@ -58,5 +59,41 @@ spec:
     memory: 1000Gi
     nvidia.com/gpu: 5
   disruption:
-    consolidationPolicy: WhenUnderutilized
-    expireAfter: 30m # ~5 minutes required for larger images, otherwise karpenter will deprovision before pods are running
+    consolidationPolicy: WhenUnderutilized | WhenEmpty
+    consolidateAfter: 15m # dont go lower to prevent decomissioning bc of image pull phase
+    expireAfter: 12h # limit GPU nodes to 12h ours
+---
+apiVersion: karpenter.sh/v1beta1
+kind: NodePool
+metadata:
+  name: long-run-gpu
+spec:
+  template:
+    spec:
+      nodeClassRef:
+        name: bettmensch-ai-default
+      requirements:
+        - key: "karpenter.k8s.aws/instance-category"
+          operator: In
+          values: ["p","g"]
+        - key: "karpenter.k8s.aws/instance-generation"
+          operator: Gt
+          values: ["2"]
+        - key: karpenter.sh/capacity-type
+          operator: In
+          values: ["on-demand"]
+      taints:
+        - key: nvidia.com/gpu
+          value: "true"
+          effect: "NoSchedule"
+        - key: long-run-gpu
+          value: "true"
+          effect: NoSchedule
+  limits:
+    cpu: 100
+    memory: 1000Gi
+    nvidia.com/gpu: 5
+  disruption:
+    consolidationPolicy: WhenUnderutilized | WhenEmpty
+    consolidateAfter: 30m # larger training images take longer to pull
+    expireAfter: 240h # limit GPU nodes to 12h ours

--- a/kubernetes/manifests/karpenter/karpenter-nodepool.yaml
+++ b/kubernetes/manifests/karpenter/karpenter-nodepool.yaml
@@ -34,7 +34,7 @@ spec:
 apiVersion: karpenter.sh/v1beta1
 kind: NodePool
 metadata:
-  name: on-demand-gpu
+  name: short-run-gpu
 spec:
   template:
     spec:
@@ -61,7 +61,7 @@ spec:
   disruption:
     consolidationPolicy: WhenUnderutilized | WhenEmpty
     consolidateAfter: 15m # dont go lower to prevent decomissioning bc of image pull phase
-    expireAfter: 12h # limit GPU nodes to 12h ours
+    expireAfter: 3h # limit GPU nodes to 3 ours - enough to train annotated transformer on one GPU (~2.8h)
 ---
 apiVersion: karpenter.sh/v1beta1
 kind: NodePool
@@ -90,8 +90,8 @@ spec:
           value: "true"
           effect: NoSchedule
   limits:
-    cpu: 100
-    memory: 1000Gi
+    cpu: 200
+    memory: 2000Gi
     nvidia.com/gpu: 5
   disruption:
     consolidationPolicy: WhenUnderutilized | WhenEmpty


### PR DESCRIPTION
The issues of failing torch ddp runs on both CPU and GPU around the half hour mark [incorrectly diagnosed as an argo context related issue](https://github.com/SebastianScherer88/bettmensch.ai/pull/44) was actually due to the karpenter nodepools being configured to remove all nodes after 30m no matter what.

This is now fixed, together with introducing short run vs long run GPU nodepools. the short run one should be used by default and currently supports all k8s tests w.r.t runtime.

Also removed the spot instances as they can get pulled as early as 30 minutes into the claim