### PR TITLE
Enable pipeline outputs

### DIFF
--- a/infrastructure/terraform/makefile
+++ b/infrastructure/terraform/makefile
@@ -1,6 +1,8 @@
 ## VARIABLES
 DIR?=infrastructure/terraform
 ARTIFACT_REPOSITORY_S3_BUCKET=bettmensch-ai-artifact-repository
+PYTEST_SUBPATH?=
+PYTEST_FLAGS?=
 
 platform.init:
 	@echo "::group::Initializing platform infrastructure environment"
@@ -28,7 +30,7 @@ platform.connect:
 
 platform.test:
 	@echo "::group:: Running e2e platform tests"
-	make sdk.test SUITE=k8s PYTEST_FLAGS="$(PYTEST_FLAGS)"
+	make sdk.test SUITE=k8s PYTEST_FLAGS="$(PYTEST_FLAGS)" PYTEST_SUBPATH="$(PYTEST_SUBPATH)"
 	@echo "::endgroup::"
 
 platform.delete_test_pipelines:

--- a/kubernetes/manifests/karpenter/karpenter-nodepool.yaml
+++ b/kubernetes/manifests/karpenter/karpenter-nodepool.yaml
@@ -49,7 +49,7 @@ spec:
           values: ["2"]
         - key: karpenter.sh/capacity-type
           operator: In
-          values: ["on-demand"]
+          values: ["spot","on-demand"]
       taints:
         - key: nvidia.com/gpu
           value: "true"
@@ -57,7 +57,7 @@ spec:
   limits:
     cpu: 100
     memory: 1000Gi
-    nvidia.com/gpu: 5
+    nvidia.com/gpu: 8
   disruption:
     consolidationPolicy: WhenEmpty
     consolidateAfter: 15m # dont go lower to prevent decomissioning bc of image pull phase
@@ -92,7 +92,7 @@ spec:
   limits:
     cpu: 200
     memory: 2000Gi
-    nvidia.com/gpu: 5
+    nvidia.com/gpu: 8
   disruption:
     consolidationPolicy: WhenEmpty
     consolidateAfter: 30m # larger training images take longer to pull

--- a/sdk/bettmensch_ai/pipelines/__init__.py
+++ b/sdk/bettmensch_ai/pipelines/__init__.py
@@ -29,8 +29,6 @@ from .io import (  # noqa: F401
 from .pipeline import (  # noqa: F401
     Flow,
     Pipeline,
-    PipelineContext,
-    _pipeline_context,
     as_pipeline,
     delete_flow,
     delete_registered_pipeline,

--- a/sdk/bettmensch_ai/pipelines/component/base/component.py
+++ b/sdk/bettmensch_ai/pipelines/component/base/component.py
@@ -343,7 +343,9 @@ class BaseComponent(object):
 
         return script_decorator_kwargs
 
-    def build_hera_task_factory(self) -> Union[Callable, List[Callable]]:
+    def build_hera_task_factory(
+        self,
+    ) -> Union[Callable[..., Task], List[Callable[..., Task]]]:
         """Generates the task factory task_wrapper callable from the
         hera.workflows.script decorator definition. Needs to be called outide
         of an active hera context.

--- a/sdk/bettmensch_ai/pipelines/component/base/component.py
+++ b/sdk/bettmensch_ai/pipelines/component/base/component.py
@@ -15,8 +15,12 @@ from bettmensch_ai.pipelines.io import (
     OutputArtifact,
     OutputParameter,
 )
-from bettmensch_ai.pipelines.pipeline.pipeline_context import _pipeline_context
-from bettmensch_ai.pipelines.utils import get_func_args, validate_func_args
+from bettmensch_ai.pipelines.pipeline_context import _pipeline_context
+from bettmensch_ai.pipelines.utils import (
+    build_container_ios,
+    get_func_args,
+    validate_func_args,
+)
 from hera.workflows import Resources, Script, Task, models
 from hera.workflows.models import ImagePullPolicy
 
@@ -84,9 +88,11 @@ class BaseComponent(object):
                 OutputArtifact,
             ],
         )
-        self.template_inputs = self.build_template_ios(func, (InputArtifact,))
-        self.template_outputs = self.build_template_ios(
-            func, (OutputParameter, OutputArtifact)
+        self.template_inputs = build_container_ios(
+            self, func, (InputArtifact,)
+        )
+        self.template_outputs = build_container_ios(
+            self, func, (OutputParameter, OutputArtifact)
         )
         self.task_inputs = self.build_task_inputs(func, task_inputs)
 
@@ -122,52 +128,6 @@ class BaseComponent(object):
         context wide unique identifier for the task node."""
 
         return f"{self.base_name}-{n}"
-
-    def build_template_ios(
-        self,
-        func: Callable,
-        annotation_types: List[
-            Union[InputArtifact, OutputParameter, OutputArtifact]
-        ],
-    ) -> Dict[str, Union[InputArtifact, OutputParameter, OutputArtifact]]:
-        """Builds the Component's template's inputs/outputs based on the
-        underlying function's arguments annotated with the
-        - InputParameter for the template inputs or
-        - OutputsParameter or the
-        - OutputArtifact
-        for the template outputs. To be used in the `build_task_factory`
-        method.
-
-        Note that InputParameter type arguments dont need to be passed
-        explicitly to hera's  @script decorator since they are inferred from
-        the decorated function's argument spec automatically.
-
-        Args:
-            func (Callable): The function the we want to wrap in a Component.
-            annotation_types:
-                List[Union[InputArtifact,OutputParameter,OutputArtifact]]: The
-                annotation types to extract.
-        Returns:
-            Dict[str,Union[
-                    InputParameter,
-                    InputArtifact,
-                    OutputParameter,
-                    OutputArtifact
-                    ]
-                ]: The component's template's inputs/outputs.
-        """
-
-        func_ios = get_func_args(func, "annotation", annotation_types)
-
-        template_ios = {}
-
-        for io_name, io_param in func_ios.items():
-            template_io = io_param.annotation(name=io_name)
-            template_io.set_owner(self)
-
-            template_ios[io_name] = template_io
-
-        return template_ios
 
     def build_task_inputs(
         self,

--- a/sdk/bettmensch_ai/pipelines/component/examples/annotated_transformer/annotated_transformer.py
+++ b/sdk/bettmensch_ai/pipelines/component/examples/annotated_transformer/annotated_transformer.py
@@ -81,23 +81,10 @@ def train_transformer(
     trained_transformer: OutputArtifact = None,
     training_config: OutputParameter = None,
 ):
-    import os
-
     from bettmensch_ai.pipelines.component.examples.annotated_transformer.training import (  # noqa: E501
         TrainConfig,
         train_worker,
     )
-
-    # make sure model artifact export directory exists
-    if trained_transformer is not None:
-        if not os.path.exists(trained_transformer.path):
-            os.makedirs(trained_transformer.path)
-
-        file_prefix = os.path.join(
-            trained_transformer.path, f"{dataset}_model_"
-        )
-    else:
-        file_prefix = os.path.join(".", f"{dataset}_model_")
 
     config = TrainConfig(
         dataset=dataset,
@@ -113,13 +100,12 @@ def train_transformer(
         base_lr=base_lr,
         max_padding=max_padding,
         warmup=warmup,
-        file_prefix=file_prefix,
+        output_directory=trained_transformer.path,
     )
 
     train_worker(config)
 
-    if training_config is not None:
-        training_config.assign(config)
+    training_config.assign(config)
 
 
 get_tokenizers_and_vocabularies_factory = as_component(

--- a/sdk/bettmensch_ai/pipelines/component/examples/annotated_transformer/annotated_transformer.py
+++ b/sdk/bettmensch_ai/pipelines/component/examples/annotated_transformer/annotated_transformer.py
@@ -78,7 +78,7 @@ def train_transformer(
     base_lr: InputParameter = 1.0,
     max_padding: InputParameter = 72,
     warmup: InputParameter = 3000,
-    trained_transformer: OutputArtifact = None,
+    model_checkpoints: OutputArtifact = None,
     training_config: OutputParameter = None,
 ):
     from bettmensch_ai.pipelines.component.examples.annotated_transformer.training import (  # noqa: E501
@@ -100,7 +100,7 @@ def train_transformer(
         base_lr=base_lr,
         max_padding=max_padding,
         warmup=warmup,
-        output_directory=trained_transformer.path,
+        output_directory=model_checkpoints.path,
     )
 
     train_worker(config)

--- a/sdk/bettmensch_ai/pipelines/component/examples/annotated_transformer/training/train.py
+++ b/sdk/bettmensch_ai/pipelines/component/examples/annotated_transformer/training/train.py
@@ -3,8 +3,8 @@ import time
 import GPUtil
 import torch
 import torch.distributed as dist
-from bettmensch_ai.components import LaunchContext
-from bettmensch_ai.components.examples.annotated_transformer.architecture import (  # noqa: E501
+from bettmensch_ai.pipelines.component import LaunchContext
+from bettmensch_ai.pipelines.component.examples.annotated_transformer.architecture import (  # noqa: E501
     EncoderDecoder,
     make_model,
 )

--- a/sdk/bettmensch_ai/pipelines/component/examples/annotated_transformer/training/utils.py
+++ b/sdk/bettmensch_ai/pipelines/component/examples/annotated_transformer/training/utils.py
@@ -90,7 +90,7 @@ class TrainConfig(BaseModel):
     base_lr: float = 1.0
     max_padding: int = 72
     warmup: int = 3000
-    file_prefix: str = "model_"
+    output_directory: str = "."
 
     @validator("dataset")
     def check_languages(v):

--- a/sdk/bettmensch_ai/pipelines/component/standard/component.py
+++ b/sdk/bettmensch_ai/pipelines/component/standard/component.py
@@ -24,7 +24,7 @@ class Component(BaseComponent):
     cpu: Optional[Union[float, int, str]] = "100m"
     memory: Optional[str] = "100Mi"
 
-    def build_hera_task_factory(self) -> Callable:
+    def build_hera_task_factory(self) -> Callable[..., Task]:
         """Generates the task factory task_wrapper callable from the
         hera.workflows.script decorator definition. Needs to be called outide
         of an active hera context.

--- a/sdk/bettmensch_ai/pipelines/component/standard/component.py
+++ b/sdk/bettmensch_ai/pipelines/component/standard/component.py
@@ -1,4 +1,4 @@
-from typing import Any, Callable, Dict, List, Optional, Type, Union
+from typing import Callable, Dict, Optional, Type, Union
 
 from bettmensch_ai.pipelines.component.base import BettmenschAIBaseScript
 from bettmensch_ai.pipelines.component.base.component import BaseComponent
@@ -72,7 +72,7 @@ class Component(BaseComponent):
 
 def as_component(
     func: Callable,
-) -> Callable[[str, Dict, List[Any]], Component]:
+) -> Callable[..., Component]:
     """Takes a calleable and generates a configured Component factory that will
     generate a Component version of the callable if invoked inside an active
     PipelineContext.

--- a/sdk/bettmensch_ai/pipelines/component/torch_ddp/component.py
+++ b/sdk/bettmensch_ai/pipelines/component/torch_ddp/component.py
@@ -176,7 +176,7 @@ class TorchDDPComponent(BaseComponent):
 
         return script_decorator_kwargs
 
-    def build_hera_task_factory(self) -> List[Callable]:
+    def build_hera_task_factory(self) -> Callable[..., Task]:
         """Generates the task factory task_wrapper callable from the
         hera.workflows.script decorator definition. Needs to be called outide
         of an active hera context.

--- a/sdk/bettmensch_ai/pipelines/component/torch_ddp/utils.py
+++ b/sdk/bettmensch_ai/pipelines/component/torch_ddp/utils.py
@@ -131,6 +131,14 @@ class LaunchContext(BaseSettings):
     # (global) node rank
     group_rank: int  # same as node_rank in the LaunchConfigSettings
 
+    @property
+    def is_local_main_process(self) -> bool:
+        return self.local_rank == 0
+
+    @property
+    def is_global_main_process(self) -> bool:
+        return self.rank == 0
+
 
 def as_torch_ddp(**config_settings_kwargs):
     """Keyword decorator that wraps a callable in a torch distributed elastic

--- a/sdk/bettmensch_ai/pipelines/io.py
+++ b/sdk/bettmensch_ai/pipelines/io.py
@@ -1,6 +1,7 @@
 import os
-from typing import Any, Union
+from typing import Any, Dict, Union
 
+from hera.shared.serialization import MISSING
 from hera.workflows import Artifact, Parameter, models
 
 from .constants import ArgumentType, IOType, ResourceType
@@ -11,7 +12,9 @@ class IO(object):
     name: str
     value: Any
 
-    def __init__(self, name: str, value: Any = None):
+    def __init__(
+        self, name: str, value: Union[str, int, float, Dict] = MISSING
+    ):
         self.name = name
         self.value = value
 

--- a/sdk/bettmensch_ai/pipelines/io.py
+++ b/sdk/bettmensch_ai/pipelines/io.py
@@ -42,10 +42,10 @@ class IO(object):
     def __eq__(self, other):
 
         return (
-            self.name == other.name
-            and self.value == other.value
-            and self.source == other.source
-            and self.owner == other.owner
+            getattr(self, "name", None) == getattr(other, "name", None)
+            and getattr(self, "value", None) == getattr(other, "value", None)
+            and getattr(self, "source", None) == getattr(other, "source", None)
+            and getattr(self, "owner", None) == getattr(other, "owner", None)
         )
 
     def __repr__(self):
@@ -78,7 +78,9 @@ class OriginMixin(object):
     source: Union["InputParameter", "OutputParameter", "OutputArtifact"] = None
     id: str = None
 
-    def set_owner(self, owner: Union["Component", "Pipeline"]):  # noqa: F821
+    def set_owner(
+        self, owner: Union["Component", "Pipeline"]  # noqa: F821
+    ) -> "OriginMixin":
         try:
             assert owner.type in (
                 ResourceType.component.value,
@@ -92,10 +94,12 @@ class OriginMixin(object):
 
         self.owner = owner
 
+        return self
+
     def set_source(
         self,
         source: Union["InputParameter", "OutputParameter", "OutputArtifact"],
-    ):
+    ) -> "OriginMixin":
         if not isinstance(
             source, (InputParameter, OutputParameter, OutputArtifact)
         ):
@@ -105,6 +109,8 @@ class OriginMixin(object):
             )
 
         self.source = source
+
+        return self
 
 
 class OriginInput(OriginMixin, Input):

--- a/sdk/bettmensch_ai/pipelines/io.py
+++ b/sdk/bettmensch_ai/pipelines/io.py
@@ -247,7 +247,10 @@ class OutputParameter(OriginOutput):
 
         if owner_type == ResourceType.pipeline.value:
             if source_owner_type == ResourceType.component.value:
-                return Parameter(name=self.name, value=self.source.id)
+                return Parameter(
+                    name=self.name,
+                    value_from=models.ValueFrom(parameter=self.source.id),
+                )
             else:
                 raise TypeError(
                     f"Invalid type for owner of source parameter:"

--- a/sdk/bettmensch_ai/pipelines/pipeline/__init__.py
+++ b/sdk/bettmensch_ai/pipelines/pipeline/__init__.py
@@ -7,4 +7,3 @@ from .pipeline import (  # noqa: F401
     get_registered_pipeline,
     list_registered_pipelines,
 )
-from .pipeline_context import PipelineContext, _pipeline_context  # noqa: F401

--- a/sdk/bettmensch_ai/pipelines/pipeline/examples/__init__.py
+++ b/sdk/bettmensch_ai/pipelines/pipeline/examples/__init__.py
@@ -1,6 +1,6 @@
 from .annotated_transformer import (  # noqa: F401
     train_transformer_pipeline_1n_1p,
-    train_transformer_pipeline_2n_1p,
+    train_transformer_pipeline_2n_2p,
 )
 from .basic import (  # noqa: F401
     adding_parameters_pipeline,

--- a/sdk/bettmensch_ai/pipelines/pipeline/examples/__init__.py
+++ b/sdk/bettmensch_ai/pipelines/pipeline/examples/__init__.py
@@ -1,5 +1,6 @@
 from .annotated_transformer import (  # noqa: F401
     train_transformer_pipeline_1n_1p,
+    train_transformer_pipeline_1n_2p,
     train_transformer_pipeline_2n_1p,
     train_transformer_pipeline_2n_2p,
 )

--- a/sdk/bettmensch_ai/pipelines/pipeline/examples/__init__.py
+++ b/sdk/bettmensch_ai/pipelines/pipeline/examples/__init__.py
@@ -1,5 +1,6 @@
 from .annotated_transformer import (  # noqa: F401
     train_transformer_pipeline_1n_1p,
+    train_transformer_pipeline_2n_1p,
     train_transformer_pipeline_2n_2p,
 )
 from .basic import (  # noqa: F401

--- a/sdk/bettmensch_ai/pipelines/pipeline/examples/annotated_transformer/__init__.py
+++ b/sdk/bettmensch_ai/pipelines/pipeline/examples/annotated_transformer/__init__.py
@@ -1,5 +1,6 @@
 from .annotated_transformer import (  # noqa: F401
     train_transformer_pipeline_1n_1p,
+    train_transformer_pipeline_1n_2p,
     train_transformer_pipeline_2n_1p,
     train_transformer_pipeline_2n_2p,
 )

--- a/sdk/bettmensch_ai/pipelines/pipeline/examples/annotated_transformer/__init__.py
+++ b/sdk/bettmensch_ai/pipelines/pipeline/examples/annotated_transformer/__init__.py
@@ -1,4 +1,5 @@
 from .annotated_transformer import (  # noqa: F401
     train_transformer_pipeline_1n_1p,
+    train_transformer_pipeline_2n_1p,
     train_transformer_pipeline_2n_2p,
 )

--- a/sdk/bettmensch_ai/pipelines/pipeline/examples/annotated_transformer/__init__.py
+++ b/sdk/bettmensch_ai/pipelines/pipeline/examples/annotated_transformer/__init__.py
@@ -1,4 +1,4 @@
 from .annotated_transformer import (  # noqa: F401
     train_transformer_pipeline_1n_1p,
-    train_transformer_pipeline_2n_1p,
+    train_transformer_pipeline_2n_2p,
 )

--- a/sdk/bettmensch_ai/pipelines/pipeline/examples/annotated_transformer/annotated_transformer.py
+++ b/sdk/bettmensch_ai/pipelines/pipeline/examples/annotated_transformer/annotated_transformer.py
@@ -57,6 +57,20 @@ def get_train_transformer_pipeline(
                 )
             ]
 
+        if n_nodes > 1:
+            # force different k8s nodes where applicable to ensure a multi-node
+            # run is genuinely multi-node not just at the torchrun level but
+            # also at the k8s level. For testing coverage purposes only
+            hera_template_kwargs[
+                "pod_spec_patch"
+            ] = """topologySpreadConstraints:
+- maxSkew: 1
+  topologyKey: kubernetes.io/hostname
+  whenUnsatisfiable: DoNotSchedule
+  labelSelector:
+    matchExpressions:
+      - { key: torch-node, operator: In, values: ['0','1','2','3','4','5']}"""
+
         train_transformer = (  # noqa: F841
             train_transformer_factory(
                 "train-transformer",

--- a/sdk/bettmensch_ai/pipelines/pipeline/examples/annotated_transformer/annotated_transformer.py
+++ b/sdk/bettmensch_ai/pipelines/pipeline/examples/annotated_transformer/annotated_transformer.py
@@ -70,7 +70,7 @@ def train_transformer_pipeline_1n_1p(
 
 
 @as_pipeline("test-train-pipeline-xn", ARGO_NAMESPACE, True)
-def train_transformer_pipeline_2n_1p(
+def train_transformer_pipeline_2n_2p(
     dataset: InputParameter = "multi30k",
     source_language: InputParameter = "de",
     target_language: InputParameter = "en",
@@ -105,7 +105,7 @@ def train_transformer_pipeline_2n_1p(
             },
             n_nodes=2,
             min_nodes=2,
-            nproc_per_node=1,
+            nproc_per_node=2,
             dataset=dataset,
             source_language=source_language,
             target_language=target_language,
@@ -126,6 +126,6 @@ def train_transformer_pipeline_2n_1p(
             warmup=warmup,
         )
         .set_cpu(3.5)  # works with 3, fails with 1
-        .set_gpus(1)
+        .set_gpus(2)
         .set_memory("15Gi")  # works with 4Gi
     )

--- a/sdk/bettmensch_ai/pipelines/pipeline/examples/annotated_transformer/annotated_transformer.py
+++ b/sdk/bettmensch_ai/pipelines/pipeline/examples/annotated_transformer/annotated_transformer.py
@@ -4,7 +4,11 @@ from bettmensch_ai.pipelines.component.examples.annotated_transformer import (
     train_transformer_factory,
 )
 from bettmensch_ai.pipelines.constants import ARGO_NAMESPACE, COMPONENT_IMAGE
-from bettmensch_ai.pipelines.io import InputParameter
+from bettmensch_ai.pipelines.io import (
+    InputParameter,
+    OutputArtifact,
+    OutputParameter,
+)
 from hera.workflows import EmptyDirVolume
 
 
@@ -24,6 +28,8 @@ def get_train_transformer_pipeline(
         base_lr: InputParameter = 1.0,
         max_padding: InputParameter = 72,
         warmup: InputParameter = 3000,
+        trained_transformer_checkpoints: OutputArtifact = None,
+        training_config: OutputParameter = None,
     ):
 
         # preprocessing component
@@ -102,6 +108,13 @@ def get_train_transformer_pipeline(
             .set_memory(
                 f"{int(4 * n_proc_per_node)}Gi"
             )  # works with 4Gi per process
+        )
+
+        trained_transformer_checkpoints.set_source(
+            train_transformer.outputs["model_checkpoints"]
+        )
+        training_config.set_source(
+            train_transformer.outputs["training_config"]
         )
 
     return train_transformer_pipeline

--- a/sdk/bettmensch_ai/pipelines/pipeline/examples/annotated_transformer/annotated_transformer.py
+++ b/sdk/bettmensch_ai/pipelines/pipeline/examples/annotated_transformer/annotated_transformer.py
@@ -94,6 +94,9 @@ def get_train_transformer_pipeline(
 
 
 train_transformer_pipeline_1n_1p = get_train_transformer_pipeline()
+train_transformer_pipeline_1n_2p = get_train_transformer_pipeline(
+    name="test-train-pipeline-1n-2p-", n_nodes=1, n_proc_per_node=2
+)
 train_transformer_pipeline_2n_1p = get_train_transformer_pipeline(
     name="test-train-pipeline-2n-1p-", n_nodes=2, n_proc_per_node=1
 )

--- a/sdk/bettmensch_ai/pipelines/pipeline/examples/annotated_transformer/annotated_transformer.py
+++ b/sdk/bettmensch_ai/pipelines/pipeline/examples/annotated_transformer/annotated_transformer.py
@@ -1,131 +1,102 @@
-from bettmensch_ai.pipelines import as_pipeline
+from bettmensch_ai.pipelines import Pipeline, as_pipeline
 from bettmensch_ai.pipelines.component.examples.annotated_transformer import (
     get_tokenizers_and_vocabularies_factory,
     train_transformer_factory,
 )
 from bettmensch_ai.pipelines.constants import ARGO_NAMESPACE, COMPONENT_IMAGE
 from bettmensch_ai.pipelines.io import InputParameter
+from hera.workflows import EmptyDirVolume
 
 
-@as_pipeline("test-train-pipeline-1n", ARGO_NAMESPACE, True)
-def train_transformer_pipeline_1n_1p(
-    dataset: InputParameter = "multi30k",
-    source_language: InputParameter = "de",
-    target_language: InputParameter = "en",
-    batch_size: InputParameter = 32,
-    num_epochs: InputParameter = 8,
-    accum_iter: InputParameter = 10,
-    base_lr: InputParameter = 1.0,
-    max_padding: InputParameter = 72,
-    warmup: InputParameter = 3000,
-):
+def get_train_transformer_pipeline(
+    name: str = "test-train-pipeline-1n-1p-",
+    n_nodes: int = 1,
+    n_proc_per_node: int = 1,
+) -> Pipeline:
+    @as_pipeline(name, ARGO_NAMESPACE, True)
+    def train_transformer_pipeline(
+        dataset: InputParameter = "multi30k",
+        source_language: InputParameter = "de",
+        target_language: InputParameter = "en",
+        batch_size: InputParameter = 32,
+        num_epochs: InputParameter = 8,
+        accum_iter: InputParameter = 10,
+        base_lr: InputParameter = 1.0,
+        max_padding: InputParameter = 72,
+        warmup: InputParameter = 3000,
+    ):
 
-    get_tokenizers_and_vocabularies = (
-        get_tokenizers_and_vocabularies_factory(
-            "preprocess",
-            hera_template_kwargs={
-                "image": COMPONENT_IMAGE.annotated_transformer.value
-            },
-            dataset=dataset,
-            source_language=source_language,
-            target_language=target_language,
-            max_padding=max_padding,
+        # preprocessing component
+        get_tokenizers_and_vocabularies = (
+            get_tokenizers_and_vocabularies_factory(
+                "preprocess",
+                hera_template_kwargs={
+                    "image": COMPONENT_IMAGE.annotated_transformer.value
+                },
+                dataset=dataset,
+                source_language=source_language,
+                target_language=target_language,
+                max_padding=max_padding,
+            )
+            .set_memory("1000Mi")
+            .set_cpu(1)
         )
-        .set_memory("1000Mi")
-        .set_cpu(1)
-    )
 
-    train_transformer = (  # noqa: F841
-        train_transformer_factory(
-            "train-transformer",
-            hera_template_kwargs={
-                "image": COMPONENT_IMAGE.annotated_transformer.value
-            },
-            n_nodes=1,
-            min_nodes=1,
-            nproc_per_node=1,
-            dataset=dataset,
-            source_language=source_language,
-            target_language=target_language,
-            source_tokenizer=get_tokenizers_and_vocabularies.outputs[
-                "source_tokenizer"
-            ],
-            target_tokenizer=get_tokenizers_and_vocabularies.outputs[
-                "target_tokenizer"
-            ],
-            vocabularies=get_tokenizers_and_vocabularies.outputs[
-                "vocabularies"
-            ],
-            batch_size=batch_size,
-            num_epochs=num_epochs,
-            accum_iter=accum_iter,
-            base_lr=base_lr,
-            max_padding=max_padding,
-            warmup=warmup,
+        # training component
+        hera_template_kwargs = {
+            "image": COMPONENT_IMAGE.annotated_transformer.value,
+        }
+
+        if n_proc_per_node > 1:
+            # enable same node gpu comms as per
+            # https://hera.readthedocs.io/en/latest/examples/workflows/...
+            # ...use-cases/fine_tune_llama/
+            hera_template_kwargs["volumes"] = [
+                EmptyDirVolume(
+                    name="gpu-comm", size_limit="15Gi", mount_path="/dev/shm"
+                )
+            ]
+
+        train_transformer = (  # noqa: F841
+            train_transformer_factory(
+                "train-transformer",
+                hera_template_kwargs=hera_template_kwargs,
+                n_nodes=n_nodes,
+                min_nodes=n_nodes,
+                nproc_per_node=n_proc_per_node,
+                dataset=dataset,
+                source_language=source_language,
+                target_language=target_language,
+                source_tokenizer=get_tokenizers_and_vocabularies.outputs[
+                    "source_tokenizer"
+                ],
+                target_tokenizer=get_tokenizers_and_vocabularies.outputs[
+                    "target_tokenizer"
+                ],
+                vocabularies=get_tokenizers_and_vocabularies.outputs[
+                    "vocabularies"
+                ],
+                batch_size=batch_size,
+                num_epochs=num_epochs,
+                accum_iter=accum_iter,
+                base_lr=base_lr,
+                max_padding=max_padding,
+                warmup=warmup,
+            )
+            .set_cpu(3 * n_proc_per_node)  # works with 3 CPUs per process
+            .set_gpus(1 * n_proc_per_node)  # 1 GPU per process
+            .set_memory(
+                f"{int(4 * n_proc_per_node)}Gi"
+            )  # works with 4Gi per process
         )
-        .set_cpu(3.5)  # works with 3, fails with 1
-        .set_gpus(1)
-        .set_memory("15Gi")  # works with 4Gi
-    )
+
+    return train_transformer_pipeline
 
 
-@as_pipeline("test-train-pipeline-xn", ARGO_NAMESPACE, True)
-def train_transformer_pipeline_2n_2p(
-    dataset: InputParameter = "multi30k",
-    source_language: InputParameter = "de",
-    target_language: InputParameter = "en",
-    batch_size: InputParameter = 32,
-    num_epochs: InputParameter = 8,
-    accum_iter: InputParameter = 10,
-    base_lr: InputParameter = 1.0,
-    max_padding: InputParameter = 72,
-    warmup: InputParameter = 3000,
-):
-
-    get_tokenizers_and_vocabularies = (
-        get_tokenizers_and_vocabularies_factory(
-            "preprocess",
-            hera_template_kwargs={
-                "image": COMPONENT_IMAGE.annotated_transformer.value
-            },
-            dataset=dataset,
-            source_language=source_language,
-            target_language=target_language,
-            max_padding=max_padding,
-        )
-        .set_memory("1000Mi")
-        .set_cpu(1)
-    )
-
-    train_transformer = (  # noqa: F841
-        train_transformer_factory(
-            "train-transformer",
-            hera_template_kwargs={
-                "image": COMPONENT_IMAGE.annotated_transformer.value
-            },
-            n_nodes=2,
-            min_nodes=2,
-            nproc_per_node=2,
-            dataset=dataset,
-            source_language=source_language,
-            target_language=target_language,
-            source_tokenizer=get_tokenizers_and_vocabularies.outputs[
-                "source_tokenizer"
-            ],
-            target_tokenizer=get_tokenizers_and_vocabularies.outputs[
-                "target_tokenizer"
-            ],
-            vocabularies=get_tokenizers_and_vocabularies.outputs[
-                "vocabularies"
-            ],
-            batch_size=batch_size,
-            num_epochs=num_epochs,
-            accum_iter=accum_iter,
-            base_lr=base_lr,
-            max_padding=max_padding,
-            warmup=warmup,
-        )
-        .set_cpu(3.5)  # works with 3, fails with 1
-        .set_gpus(2)
-        .set_memory("15Gi")  # works with 4Gi
-    )
+train_transformer_pipeline_1n_1p = get_train_transformer_pipeline()
+train_transformer_pipeline_2n_1p = get_train_transformer_pipeline(
+    name="test-train-pipeline-2n-1p-", n_nodes=2, n_proc_per_node=1
+)
+train_transformer_pipeline_2n_2p = get_train_transformer_pipeline(
+    name="test-train-pipeline-2n-2p-", n_nodes=2, n_proc_per_node=2
+)

--- a/sdk/bettmensch_ai/pipelines/pipeline/examples/basic.py
+++ b/sdk/bettmensch_ai/pipelines/pipeline/examples/basic.py
@@ -5,27 +5,35 @@ from bettmensch_ai.pipelines.component.examples import (
     show_artifact_factory,
 )
 from bettmensch_ai.pipelines.constants import ARGO_NAMESPACE
-from bettmensch_ai.pipelines.io import InputParameter
+from bettmensch_ai.pipelines.io import (
+    InputParameter,
+    OutputArtifact,
+    OutputParameter,
+)
 
 
 @as_pipeline("test-artifact-pipeline", ARGO_NAMESPACE, True)
 def parameter_to_artifact_pipeline(
     a: InputParameter = "Param A",
+    b: OutputArtifact = None,
 ) -> None:
     convert = convert_to_artifact_factory(
         "convert-to-artifact",
         a=a,
     )
 
-    show_artifact_factory(
+    show_artifact = show_artifact_factory(
         "show-artifact",
         a=convert.outputs["a_art"],
     )
 
+    # assign pipeline output
+    b.set_source(show_artifact.outputs["b"])
+
 
 @as_pipeline("test-parameter-pipeline", ARGO_NAMESPACE, True)
 def adding_parameters_pipeline(
-    a: InputParameter = 1, b: InputParameter = 2
+    a: InputParameter = 1, b: InputParameter = 2, sum: OutputParameter = None
 ) -> None:
     a_plus_b = add_parameters_factory(
         "a-plus-b",
@@ -33,8 +41,11 @@ def adding_parameters_pipeline(
         b=b,
     )
 
-    add_parameters_factory(
+    a_plus_b_plus_2 = add_parameters_factory(
         "a-plus-b-plus-2",
         a=a_plus_b.outputs["sum"],
         b=InputParameter("two", 2),
     )
+
+    # assign pipeline output
+    sum.set_source(a_plus_b_plus_2.outputs["sum"])

--- a/sdk/bettmensch_ai/pipelines/pipeline/flow.py
+++ b/sdk/bettmensch_ai/pipelines/pipeline/flow.py
@@ -5,7 +5,7 @@ from bettmensch_ai.pipelines.constants import (
     FLOW_LABEL,
     FLOW_PHASE,
 )
-from bettmensch_ai.pipelines.pipeline import hera_client
+from bettmensch_ai.pipelines.pipeline.client import hera_client
 from hera.workflows import Workflow
 from hera.workflows.models import Workflow as WorkflowModel
 from hera.workflows.models import (
@@ -87,16 +87,19 @@ class Flow(object):
         return self.registered_flow.status.finished_at
 
     @classmethod
-    def from_workflow(cls, workflow: Workflow) -> "Flow":
-        """Class method to initialize a Flow instance from a
-        Workflow instance.
+    def from_workflow_model(cls, workflow_model: WorkflowModel) -> "Flow":
+        """Class method to initialize a Flow instance from a WorkflowModel
+        instance.
 
         Args:
-            workflow (Workflow): An instance of hera's Workflow class
+            workflow_model (WorkflowModel): An instance of hera's WorkflowModel
+                class
 
         Returns:
             Flow: The (registered) Flow instance.
         """
+
+        workflow: Workflow = Workflow.from_dict(workflow_model.dict())
 
         return cls(registered_flow=workflow)
 
@@ -119,9 +122,7 @@ def get_flow(
         namespace=registered_namespace, name=registered_name
     )
 
-    workflow: Workflow = Workflow.from_dict(workflow_model.dict())
-
-    flow: Flow = Flow.from_workflow(workflow)
+    flow: Flow = Flow.from_workflow_model(workflow_model)
 
     return flow
 
@@ -190,13 +191,9 @@ def list_flows(
     )
 
     if response.items is not None:
-        workflows: List[Workflow] = [
-            Workflow.from_dict(workflow_model.dict())
-            for workflow_model in response.items
-        ]
-
         flows: List[Flow] = [
-            Flow.from_workflow(workflow) for workflow in workflows
+            Flow.from_workflow_model(workflow_model)
+            for workflow_model in response.items
         ]
     else:
         flows = []

--- a/sdk/bettmensch_ai/pipelines/pipeline/pipeline.py
+++ b/sdk/bettmensch_ai/pipelines/pipeline/pipeline.py
@@ -279,9 +279,9 @@ class Pipeline(object):
         inner_dag_template_inputs = {}
         required_inner_dag_template_inputs = {}
 
-        wft_template_inputs = (
-            self.registered_workflow_template.arguments.parameters
-        )
+        wft_template_inputs = self.registered_workflow_template.templates[
+            0
+        ].inputs.parameters
 
         for wft_input in wft_template_inputs:
             inner_dag_template_input = InputParameter(
@@ -301,7 +301,30 @@ class Pipeline(object):
     def build_outputs_from_wft(
         self,
     ) -> Dict[str, Union[OutputParameter, OutputArtifact]]:
-        return {}
+
+        inner_dag_template_outputs = {}
+
+        wft_template_output_parameters = (
+            self.registered_workflow_template.templates[0].outputs.parameters
+        )
+
+        wft_template_output_artifacts = (
+            self.registered_workflow_template.templates[0].outputs.artifacts
+        )
+
+        for wft_output_parameter in wft_template_output_parameters:
+            inner_dag_template_outputs[
+                wft_output_parameter.name
+            ] = OutputParameter(name=wft_output_parameter.name,).set_owner(
+                self
+            )
+
+        for wft_output_artifact in wft_template_output_artifacts:
+            inner_dag_template_outputs[
+                wft_output_artifact.name
+            ] = OutputArtifact(name=wft_output_artifact.name,).set_owner(self)
+
+        return inner_dag_template_outputs
 
     def build_inner_dag(self) -> DAG:
 

--- a/sdk/test/k8s/pipelines/pipeline/examples/test_annotated_transformer_pipeline.py
+++ b/sdk/test/k8s/pipelines/pipeline/examples/test_annotated_transformer_pipeline.py
@@ -1,6 +1,7 @@
 import pytest
 from bettmensch_ai.pipelines.pipeline.examples import (
     train_transformer_pipeline_1n_1p,
+    train_transformer_pipeline_1n_2p,
     train_transformer_pipeline_2n_1p,
     train_transformer_pipeline_2n_2p,
 )
@@ -49,8 +50,50 @@ def test_train_transformer_pipeline_1n_1p_decorator_and_register_and_run(
 
 
 @pytest.mark.train_transformer
-@pytest.mark.multi_node_single_gpu
+@pytest.mark.single_node_multi_gpu
 @pytest.mark.order(12)
+def test_train_transformer_pipeline_1n_2p_decorator_and_register_and_run(
+    test_output_dir, test_namespace
+):
+    train_transformer_pipeline_1n_2p.export(test_output_dir)
+
+    assert not train_transformer_pipeline_1n_2p.registered
+    assert train_transformer_pipeline_1n_2p.registered_id is None
+    assert train_transformer_pipeline_1n_2p.registered_name is None
+    assert train_transformer_pipeline_1n_2p.registered_namespace is None
+
+    train_transformer_pipeline_1n_2p.register()
+
+    assert train_transformer_pipeline_1n_2p.registered
+    assert train_transformer_pipeline_1n_2p.registered_id is not None
+    assert train_transformer_pipeline_1n_2p.registered_name.startswith(
+        f"pipeline-{train_transformer_pipeline_1n_2p.name}-"
+    )
+    assert (
+        train_transformer_pipeline_1n_2p.registered_namespace == test_namespace
+    )  # noqa: E501
+
+    train_transformer_flow = train_transformer_pipeline_1n_2p.run(
+        inputs={
+            "dataset": "multi30k",
+            "source_language": "de",
+            "target_language": "en",
+            "batch_size": 32,
+            "num_epochs": 1,
+            "accum_iter": 10,
+            "base_lr": 1.0,
+            "max_padding": 72,
+            "warmup": 3000,
+        },
+        wait=True,
+    )
+
+    assert train_transformer_flow.status.phase == "Succeeded"
+
+
+@pytest.mark.train_transformer
+@pytest.mark.multi_node_single_gpu
+@pytest.mark.order(13)
 def test_train_transformer_pipeline_2n_1p_decorator_and_register_and_run(
     test_output_dir, test_namespace
 ):
@@ -92,7 +135,7 @@ def test_train_transformer_pipeline_2n_1p_decorator_and_register_and_run(
 
 @pytest.mark.train_transformer
 @pytest.mark.multi_node_multi_gpu
-@pytest.mark.order(13)
+@pytest.mark.order(14)
 def test_train_transformer_pipeline_2n_2p_decorator_and_register_and_run(
     test_output_dir, test_namespace
 ):

--- a/sdk/test/k8s/pipelines/pipeline/examples/test_annotated_transformer_pipeline.py
+++ b/sdk/test/k8s/pipelines/pipeline/examples/test_annotated_transformer_pipeline.py
@@ -1,12 +1,14 @@
 import pytest
 from bettmensch_ai.pipelines.pipeline.examples import (
     train_transformer_pipeline_1n_1p,
+    train_transformer_pipeline_2n_1p,
     train_transformer_pipeline_2n_2p,
 )
 
 
 @pytest.mark.train_transformer
 @pytest.mark.single_node_single_gpu
+@pytest.mark.order(11)
 def test_train_transformer_pipeline_1n_1p_decorator_and_register_and_run(
     test_output_dir, test_namespace
 ):
@@ -34,7 +36,49 @@ def test_train_transformer_pipeline_1n_1p_decorator_and_register_and_run(
             "source_language": "de",
             "target_language": "en",
             "batch_size": 32,
-            "num_epochs": 2,
+            "num_epochs": 1,
+            "accum_iter": 10,
+            "base_lr": 1.0,
+            "max_padding": 72,
+            "warmup": 3000,
+        },
+        wait=True,
+    )
+
+    assert train_transformer_flow.status.phase == "Succeeded"
+
+
+@pytest.mark.train_transformer
+@pytest.mark.multi_node_single_gpu
+@pytest.mark.order(12)
+def test_train_transformer_pipeline_2n_1p_decorator_and_register_and_run(
+    test_output_dir, test_namespace
+):
+    train_transformer_pipeline_2n_1p.export(test_output_dir)
+
+    assert not train_transformer_pipeline_2n_1p.registered
+    assert train_transformer_pipeline_2n_1p.registered_id is None
+    assert train_transformer_pipeline_2n_1p.registered_name is None
+    assert train_transformer_pipeline_2n_1p.registered_namespace is None
+
+    train_transformer_pipeline_2n_1p.register()
+
+    assert train_transformer_pipeline_2n_1p.registered
+    assert train_transformer_pipeline_2n_1p.registered_id is not None
+    assert train_transformer_pipeline_2n_1p.registered_name.startswith(
+        f"pipeline-{train_transformer_pipeline_2n_1p.name}-"
+    )
+    assert (
+        train_transformer_pipeline_2n_1p.registered_namespace == test_namespace
+    )  # noqa: E501
+
+    train_transformer_flow = train_transformer_pipeline_2n_1p.run(
+        inputs={
+            "dataset": "multi30k",
+            "source_language": "de",
+            "target_language": "en",
+            "batch_size": 32,
+            "num_epochs": 1,
             "accum_iter": 10,
             "base_lr": 1.0,
             "max_padding": 72,
@@ -48,6 +92,7 @@ def test_train_transformer_pipeline_1n_1p_decorator_and_register_and_run(
 
 @pytest.mark.train_transformer
 @pytest.mark.multi_node_multi_gpu
+@pytest.mark.order(13)
 def test_train_transformer_pipeline_2n_2p_decorator_and_register_and_run(
     test_output_dir, test_namespace
 ):
@@ -75,7 +120,7 @@ def test_train_transformer_pipeline_2n_2p_decorator_and_register_and_run(
             "source_language": "de",
             "target_language": "en",
             "batch_size": 32,
-            "num_epochs": 2,
+            "num_epochs": 1,
             "accum_iter": 10,
             "base_lr": 1.0,
             "max_padding": 72,

--- a/sdk/test/k8s/pipelines/pipeline/examples/test_annotated_transformer_pipeline.py
+++ b/sdk/test/k8s/pipelines/pipeline/examples/test_annotated_transformer_pipeline.py
@@ -1,7 +1,7 @@
 import pytest
 from bettmensch_ai.pipelines.pipeline.examples import (
     train_transformer_pipeline_1n_1p,
-    train_transformer_pipeline_2n_1p,
+    train_transformer_pipeline_2n_2p,
 )
 
 
@@ -48,28 +48,28 @@ def test_train_transformer_pipeline_1n_1p_decorator_and_register_and_run(
 
 @pytest.mark.train_transformer
 @pytest.mark.multi_node_multi_gpu
-def test_train_transformer_pipeline_2n_1p_decorator_and_register_and_run(
+def test_train_transformer_pipeline_2n_2p_decorator_and_register_and_run(
     test_output_dir, test_namespace
 ):
-    train_transformer_pipeline_2n_1p.export(test_output_dir)
+    train_transformer_pipeline_2n_2p.export(test_output_dir)
 
-    assert not train_transformer_pipeline_2n_1p.registered
-    assert train_transformer_pipeline_2n_1p.registered_id is None
-    assert train_transformer_pipeline_2n_1p.registered_name is None
-    assert train_transformer_pipeline_2n_1p.registered_namespace is None
+    assert not train_transformer_pipeline_2n_2p.registered
+    assert train_transformer_pipeline_2n_2p.registered_id is None
+    assert train_transformer_pipeline_2n_2p.registered_name is None
+    assert train_transformer_pipeline_2n_2p.registered_namespace is None
 
-    train_transformer_pipeline_2n_1p.register()
+    train_transformer_pipeline_2n_2p.register()
 
-    assert train_transformer_pipeline_2n_1p.registered
-    assert train_transformer_pipeline_2n_1p.registered_id is not None
-    assert train_transformer_pipeline_2n_1p.registered_name.startswith(
-        f"pipeline-{train_transformer_pipeline_2n_1p.name}-"
+    assert train_transformer_pipeline_2n_2p.registered
+    assert train_transformer_pipeline_2n_2p.registered_id is not None
+    assert train_transformer_pipeline_2n_2p.registered_name.startswith(
+        f"pipeline-{train_transformer_pipeline_2n_2p.name}-"
     )
     assert (
-        train_transformer_pipeline_2n_1p.registered_namespace == test_namespace
+        train_transformer_pipeline_2n_2p.registered_namespace == test_namespace
     )  # noqa: E501
 
-    train_transformer_flow = train_transformer_pipeline_2n_1p.run(
+    train_transformer_flow = train_transformer_pipeline_2n_2p.run(
         inputs={
             "dataset": "multi30k",
             "source_language": "de",

--- a/sdk/test/k8s/pipelines/pipeline/examples/test_annotated_transformer_pipeline.py
+++ b/sdk/test/k8s/pipelines/pipeline/examples/test_annotated_transformer_pipeline.py
@@ -13,12 +13,6 @@ from bettmensch_ai.pipelines.pipeline.examples import (
 def test_train_transformer_pipeline_1n_1p_decorator_and_register_and_run(
     test_output_dir, test_namespace
 ):
-    train_transformer_pipeline_1n_1p.export(test_output_dir)
-
-    assert not train_transformer_pipeline_1n_1p.registered
-    assert train_transformer_pipeline_1n_1p.registered_id is None
-    assert train_transformer_pipeline_1n_1p.registered_name is None
-    assert train_transformer_pipeline_1n_1p.registered_namespace is None
 
     train_transformer_pipeline_1n_1p.register()
 

--- a/sdk/test/k8s/pipelines/pipeline/test_flow.py
+++ b/sdk/test/k8s/pipelines/pipeline/test_flow.py
@@ -20,7 +20,7 @@ def test_get_standard_flow(test_namespace):
 @pytest.mark.ddp
 @pytest.mark.train_transformer
 @pytest.mark.delete_flows
-@pytest.mark.order(11)
+@pytest.mark.order(14)
 def test_delete(test_namespace):
     """Test the delete_flow function"""
 

--- a/sdk/test/k8s/pipelines/pipeline/test_flow.py
+++ b/sdk/test/k8s/pipelines/pipeline/test_flow.py
@@ -20,7 +20,7 @@ def test_get_standard_flow(test_namespace):
 @pytest.mark.ddp
 @pytest.mark.train_transformer
 @pytest.mark.delete_flows
-@pytest.mark.order(14)
+@pytest.mark.order(15)
 def test_delete(test_namespace):
     """Test the delete_flow function"""
 

--- a/sdk/test/k8s/pipelines/pipeline/test_pipeline.py
+++ b/sdk/test/k8s/pipelines/pipeline/test_pipeline.py
@@ -450,7 +450,7 @@ def test_run_dpp_registered_pipelines_from_registry(
 @pytest.mark.ddp
 @pytest.mark.train_transformer
 @pytest.mark.delete_pipelines
-@pytest.mark.order(15)
+@pytest.mark.order(16)
 def test_delete_registered_pipeline(test_namespace):
     """Test the delete_registered_pipeline function"""
 

--- a/sdk/test/k8s/pipelines/pipeline/test_pipeline.py
+++ b/sdk/test/k8s/pipelines/pipeline/test_pipeline.py
@@ -450,7 +450,7 @@ def test_run_dpp_registered_pipelines_from_registry(
 @pytest.mark.ddp
 @pytest.mark.train_transformer
 @pytest.mark.delete_pipelines
-@pytest.mark.order(12)
+@pytest.mark.order(15)
 def test_delete_registered_pipeline(test_namespace):
     """Test the delete_registered_pipeline function"""
 

--- a/sdk/test/k8s/pipelines/pipeline/test_pipeline.py
+++ b/sdk/test/k8s/pipelines/pipeline/test_pipeline.py
@@ -28,6 +28,10 @@ def test_artifact_pipeline_decorator_and_register_and_run(
     """Registers and runs an example Pipeline passing artifacts across
     components."""
 
+    # export pipeline to allow for manual checks
+    parameter_to_artifact_pipeline.export(test_output_dir)
+
+    # register workflow template with argo server on k8s cluster
     parameter_to_artifact_pipeline.register()
 
     assert parameter_to_artifact_pipeline.registered
@@ -57,6 +61,10 @@ def test_parameter_pipeline_decorator_and_register_and_run(
     """Registers and runs an example Pipeline passing parameters across
     components."""
 
+    # export pipeline to allow for manual checks
+    adding_parameters_pipeline.export(test_output_dir)
+
+    # register workflow template with argo server on k8s cluster
     adding_parameters_pipeline.register()
 
     assert adding_parameters_pipeline.registered

--- a/sdk/test/k8s/pipelines/pipeline/test_pipeline.py
+++ b/sdk/test/k8s/pipelines/pipeline/test_pipeline.py
@@ -4,7 +4,6 @@ from bettmensch_ai.pipelines import (
     Pipeline,
     as_pipeline,
     delete_registered_pipeline,
-    get_registered_pipeline,
     list_registered_pipelines,
 )
 from bettmensch_ai.pipelines.component.examples import (
@@ -43,6 +42,20 @@ def test_artifact_pipeline_decorator_and_register_and_run(
         parameter_to_artifact_pipeline.registered_namespace == test_namespace
     )  # noqa: E501
 
+    # test outputs of `build_inputs_from_wft`
+    assert parameter_to_artifact_pipeline.inputs == {
+        "a": InputParameter(name="a", value="Param A").set_owner(
+            parameter_to_artifact_pipeline
+        ),
+    }
+    assert parameter_to_artifact_pipeline.required_inputs == {}
+    # test outputs of `build_outputs_from_wft`
+    # we dont have access to the output's Component type owner, so can only
+    # verify the name here.
+    assert list(parameter_to_artifact_pipeline.outputs.keys()) == [
+        "b",
+    ]
+
     parameter_to_artifact_flow = parameter_to_artifact_pipeline.run(
         {
             "a": "First integration test value a",
@@ -73,6 +86,23 @@ def test_parameter_pipeline_decorator_and_register_and_run(
         f"pipeline-{adding_parameters_pipeline.name}-"
     )
     assert adding_parameters_pipeline.registered_namespace == test_namespace
+
+    # test outputs of `build_inputs_from_wft`
+    assert adding_parameters_pipeline.inputs == {
+        "a": InputParameter(name="a", value=1).set_owner(
+            adding_parameters_pipeline
+        ),
+        "b": InputParameter(name="b", value=2).set_owner(
+            adding_parameters_pipeline
+        ),
+    }
+    assert adding_parameters_pipeline.required_inputs == {}
+    # test outputs of `build_outputs_from_wft`
+    # we dont have access to the output's Component type owner, so can only
+    # verify the name here.
+    assert list(adding_parameters_pipeline.outputs.keys()) == [
+        "sum",
+    ]
 
     adding_parameters_flow = adding_parameters_pipeline.run(
         {"a": -100, "b": 100}, wait=True
@@ -197,7 +227,7 @@ def test_run_standard_registered_pipelines_from_registry(
         registered_name_pattern=test_registered_pipeline_name_pattern,
     )[0].registered_name
 
-    registered_pipeline = get_registered_pipeline(
+    registered_pipeline = Pipeline.from_registry(
         registered_pipeline_name, test_namespace
     )
 
@@ -425,7 +455,7 @@ def test_run_dpp_registered_pipelines_from_registry(
         registered_name_pattern=test_registered_pipeline_name_pattern,
     )[0].registered_name
 
-    registered_pipeline = get_registered_pipeline(
+    registered_pipeline = Pipeline.from_registry(
         registered_pipeline_name, test_namespace
     )
 

--- a/sdk/test/k8s/pipelines/pipeline/test_pipeline.py
+++ b/sdk/test/k8s/pipelines/pipeline/test_pipeline.py
@@ -28,13 +28,6 @@ def test_artifact_pipeline_decorator_and_register_and_run(
     """Registers and runs an example Pipeline passing artifacts across
     components."""
 
-    parameter_to_artifact_pipeline.export(test_output_dir)
-
-    assert not parameter_to_artifact_pipeline.registered
-    assert parameter_to_artifact_pipeline.registered_id is None
-    assert parameter_to_artifact_pipeline.registered_name is None
-    assert parameter_to_artifact_pipeline.registered_namespace is None
-
     parameter_to_artifact_pipeline.register()
 
     assert parameter_to_artifact_pipeline.registered
@@ -63,13 +56,6 @@ def test_parameter_pipeline_decorator_and_register_and_run(
 ):
     """Registers and runs an example Pipeline passing parameters across
     components."""
-
-    adding_parameters_pipeline.export(test_output_dir)
-
-    assert not adding_parameters_pipeline.registered
-    assert adding_parameters_pipeline.registered_id is None
-    assert adding_parameters_pipeline.registered_name is None
-    assert adding_parameters_pipeline.registered_namespace is None
 
     adding_parameters_pipeline.register()
 

--- a/sdk/test/unit/pipelines/component/test_adapter_component.py
+++ b/sdk/test/unit/pipelines/component/test_adapter_component.py
@@ -16,7 +16,7 @@ from bettmensch_ai.pipelines.io import (
     OutputArtifact,
     OutputParameter,
 )
-from bettmensch_ai.pipelines.pipeline import _pipeline_context
+from bettmensch_ai.pipelines.pipeline_context import _pipeline_context
 from hera.workflows import DAG, Parameter, WorkflowTemplate
 
 

--- a/sdk/test/unit/pipelines/component/test_component.py
+++ b/sdk/test/unit/pipelines/component/test_component.py
@@ -11,6 +11,7 @@ from bettmensch_ai.pipelines.io import (
     OutputParameter,
 )
 from bettmensch_ai.pipelines.pipeline import _pipeline_context
+from hera.shared.serialization import MISSING
 from hera.workflows import DAG, Parameter, WorkflowTemplate
 
 
@@ -62,7 +63,7 @@ def test_component___init__(test_function_and_task_inputs):
 
     assert test_component.task_inputs["a"].value == test_task_inputs["a"].value
     assert test_component.task_inputs["b"].value == test_task_inputs["b"].value
-    assert test_component.task_inputs["c"].value is None
+    assert test_component.task_inputs["c"].value == MISSING
 
     # validate component template_inputs
     assert list(test_component.template_inputs.keys()) == ["d"]
@@ -131,7 +132,7 @@ def test_component_decorator(
 
     assert test_component.task_inputs["a"].value == test_task_inputs["a"].value
     assert test_component.task_inputs["b"].value == test_task_inputs["b"].value
-    assert test_component.task_inputs["c"].value is None
+    assert test_component.task_inputs["c"].value == MISSING
 
     # validate component template_inputs
     assert list(test_component.template_inputs.keys()) == ["d"]

--- a/sdk/test/unit/pipelines/component/test_component.py
+++ b/sdk/test/unit/pipelines/component/test_component.py
@@ -10,7 +10,7 @@ from bettmensch_ai.pipelines.io import (
     OutputArtifact,
     OutputParameter,
 )
-from bettmensch_ai.pipelines.pipeline import _pipeline_context
+from bettmensch_ai.pipelines.pipeline_context import _pipeline_context
 from hera.shared.serialization import MISSING
 from hera.workflows import DAG, Parameter, WorkflowTemplate
 

--- a/sdk/test/unit/pipelines/component/test_torch_ddp_component.py
+++ b/sdk/test/unit/pipelines/component/test_torch_ddp_component.py
@@ -14,6 +14,7 @@ from bettmensch_ai.pipelines.io import (
     OutputParameter,
 )
 from bettmensch_ai.pipelines.pipeline import _pipeline_context
+from hera.shared.serialization import MISSING
 from hera.workflows import DAG, Parameter, WorkflowTemplate
 
 
@@ -98,7 +99,7 @@ def test_torch_component___init__(test_mock_pipeline, test_mock_component):
 
     assert test_component.task_inputs["a"].value == task_inputs["a"].value
     assert test_component.task_inputs["b"].value == task_inputs["b"].value
-    assert test_component.task_inputs["c"].value is None
+    assert test_component.task_inputs["c"].value == MISSING
 
     # validate component template_inputs
     assert list(test_component.template_inputs.keys()) == ["d"]
@@ -197,7 +198,7 @@ def test_torch_component_decorator(test_mock_pipeline, test_mock_component):
 
     assert test_component.task_inputs["a"].value == task_inputs["a"].value
     assert test_component.task_inputs["b"].value == task_inputs["b"].value
-    assert test_component.task_inputs["c"].value is None
+    assert test_component.task_inputs["c"].value == MISSING
 
     # validate component template_inputs
     assert list(test_component.template_inputs.keys()) == ["d"]

--- a/sdk/test/unit/pipelines/component/test_torch_ddp_component.py
+++ b/sdk/test/unit/pipelines/component/test_torch_ddp_component.py
@@ -13,7 +13,7 @@ from bettmensch_ai.pipelines.io import (
     OutputArtifact,
     OutputParameter,
 )
-from bettmensch_ai.pipelines.pipeline import _pipeline_context
+from bettmensch_ai.pipelines.pipeline_context import _pipeline_context
 from hera.shared.serialization import MISSING
 from hera.workflows import DAG, Parameter, WorkflowTemplate
 

--- a/sdk/test/unit/pipelines/pipeline/test_pipeline.py
+++ b/sdk/test/unit/pipelines/pipeline/test_pipeline.py
@@ -1,10 +1,7 @@
-from bettmensch_ai.pipelines.component.examples import (
-    add_parameters_factory,
-    convert_to_artifact_factory,
-    show_parameter_factory,
+from bettmensch_ai.pipelines.pipeline.examples import (
+    adding_parameters_pipeline,
+    parameter_to_artifact_pipeline,
 )
-from bettmensch_ai.pipelines.io import InputParameter
-from bettmensch_ai.pipelines.pipeline import as_pipeline
 from hera.workflows import WorkflowTemplate
 
 
@@ -13,51 +10,45 @@ def test_artifact_pipeline(
 ):
     """Declaration of Pipeline using InputArtifact and OutputArtifact"""
 
-    @as_pipeline("test-artifact-pipeline", "argo", True)
-    def parameter_to_artifact(
-        a: InputParameter = "Param A",
-    ) -> None:
-        convert = convert_to_artifact_factory(
-            "convert-to-artifact",
-            a=a,
-        )
-
-        show_parameter_factory(
-            "show-artifact",
-            a=convert.outputs["a_art"],
-        )
-
-    assert parameter_to_artifact.built
-    assert not parameter_to_artifact.registered
-    assert parameter_to_artifact.registered_id is None
-    assert parameter_to_artifact.registered_name is None
-    assert parameter_to_artifact.registered_namespace is None
-    assert set(parameter_to_artifact.workflow_template_inputs.keys()) == {"a"}
-    assert set(parameter_to_artifact.inner_dag_task_inputs.keys()) == {"a"}
+    assert parameter_to_artifact_pipeline.built
+    assert not parameter_to_artifact_pipeline.registered
+    assert parameter_to_artifact_pipeline.registered_id is None
+    assert parameter_to_artifact_pipeline.registered_name is None
+    assert parameter_to_artifact_pipeline.registered_namespace is None
+    assert set(
+        parameter_to_artifact_pipeline.inner_dag_template_inputs.keys()
+    ) == {"a"}
+    assert set(
+        parameter_to_artifact_pipeline.inner_dag_template_outputs.keys()
+    ) == {"b"}
+    assert set(
+        parameter_to_artifact_pipeline.inner_dag_task_inputs.keys()
+    ) == {"a"}
     for pipeline_input_name, pipeline_input_default in (("a", "Param A"),):
         assert (
-            parameter_to_artifact.workflow_template_inputs[
+            parameter_to_artifact_pipeline.inner_dag_template_inputs[
                 pipeline_input_name
             ].name
             == pipeline_input_name
         )
         assert (
-            parameter_to_artifact.workflow_template_inputs[
+            parameter_to_artifact_pipeline.inner_dag_template_inputs[
                 pipeline_input_name
             ].owner
-            == parameter_to_artifact
+            == parameter_to_artifact_pipeline
         )
         assert (
-            parameter_to_artifact.workflow_template_inputs[
+            parameter_to_artifact_pipeline.inner_dag_template_inputs[
                 pipeline_input_name
             ].value
             == pipeline_input_default
         )
     assert isinstance(
-        parameter_to_artifact.user_built_workflow_template, WorkflowTemplate
+        parameter_to_artifact_pipeline.user_built_workflow_template,
+        WorkflowTemplate,
     )
 
-    wft = parameter_to_artifact.user_built_workflow_template
+    wft = parameter_to_artifact_pipeline.user_built_workflow_template
 
     task_names = [task.name for task in wft.templates[0].tasks]
     assert task_names == [
@@ -73,56 +64,64 @@ def test_artifact_pipeline(
         "bettmensch-ai-outer-dag",
     ]
 
-    parameter_to_artifact.export(test_output_dir)
+    parameter_to_artifact_pipeline.export(test_output_dir)
 
 
 def test_parameter_pipeline(test_output_dir):
     """Declaration of Pipeline using InputParameter and OutputParameter"""
 
-    @as_pipeline("test-parameter-pipeline", "argo", True)
-    def adding_parameters(
-        a: InputParameter = 1, b: InputParameter = 2
-    ) -> None:  # noqa: E501
-        a_plus_b = add_parameters_factory(
-            "a-plus-b",
-            a=a,
-            b=b,
-        )
+    # @as_pipeline("test-parameter-pipeline", "argo", True)
+    # def adding_parameters(
+    #     a: InputParameter = 1, b: InputParameter = 2
+    # ) -> None:  # noqa: E501
+    #     a_plus_b = add_parameters_factory(
+    #         "a-plus-b",
+    #         a=a,
+    #         b=b,
+    #     )
 
-        add_parameters_factory(
-            "a-plus-b-plus-2",
-            a=a_plus_b.outputs["sum"],
-            b=InputParameter("two", 2),
-        )
+    #     add_parameters_factory(
+    #         "a-plus-b-plus-2",
+    #         a=a_plus_b.outputs["sum"],
+    #         b=InputParameter("two", 2),
+    #     )
 
-    assert adding_parameters.built
-    assert not adding_parameters.registered
-    assert adding_parameters.registered_id is None
-    assert adding_parameters.registered_name is None
-    assert adding_parameters.registered_namespace is None
-    assert set(adding_parameters.workflow_template_inputs.keys()) == {"a", "b"}
-    assert set(adding_parameters.inner_dag_task_inputs.keys()) == {"a", "b"}
+    assert adding_parameters_pipeline.built
+    assert not adding_parameters_pipeline.registered
+    assert adding_parameters_pipeline.registered_id is None
+    assert adding_parameters_pipeline.registered_name is None
+    assert adding_parameters_pipeline.registered_namespace is None
+    assert set(
+        adding_parameters_pipeline.inner_dag_template_inputs.keys()
+    ) == {"a", "b"}
+    assert set(
+        adding_parameters_pipeline.inner_dag_template_outputs.keys()
+    ) == {"sum"}
+    assert set(adding_parameters_pipeline.inner_dag_task_inputs.keys()) == {
+        "a",
+        "b",
+    }
     for pipeline_input_name, pipeline_input_default in (("a", 1), ("b", 2)):
         assert (
-            adding_parameters.workflow_template_inputs[
+            adding_parameters_pipeline.inner_dag_template_inputs[
                 pipeline_input_name
             ].name
             == pipeline_input_name
         )
         assert (
-            adding_parameters.workflow_template_inputs[
+            adding_parameters_pipeline.inner_dag_template_inputs[
                 pipeline_input_name
             ].owner
-            == adding_parameters
+            == adding_parameters_pipeline
         )
         assert (
-            adding_parameters.workflow_template_inputs[
+            adding_parameters_pipeline.inner_dag_template_inputs[
                 pipeline_input_name
             ].value
             == pipeline_input_default
         )
 
-    wft = adding_parameters.user_built_workflow_template
+    wft = adding_parameters_pipeline.user_built_workflow_template
 
     task_names = [task.name for task in wft.templates[0].tasks]
     assert task_names == [
@@ -138,4 +137,4 @@ def test_parameter_pipeline(test_output_dir):
         "bettmensch-ai-outer-dag",
     ]
 
-    adding_parameters.export(test_output_dir)
+    adding_parameters_pipeline.export(test_output_dir)

--- a/sdk/test/unit/pipelines/pipeline/test_pipeline.py
+++ b/sdk/test/unit/pipelines/pipeline/test_pipeline.py
@@ -22,17 +22,20 @@ def test_artifact_pipeline(
     assert parameter_to_artifact_pipeline.registered_namespace is None
 
     # --- validate pipeline instance's io attributes
+    # test outputs of `build_inputs_from_func`
     assert parameter_to_artifact_pipeline.inputs == {
         "a": InputParameter(name="a", value="Param A").set_owner(
             parameter_to_artifact_pipeline
         ),
     }
     assert parameter_to_artifact_pipeline.required_inputs == {}
+    # test outputs of `build_outputs_from_func`
     # we dont have access to the output's Component type owner, so can only
     # verify the name here.
     assert list(parameter_to_artifact_pipeline.outputs.keys()) == [
         "b",
     ]
+    # test outputs of `build_task_inputs`
     assert parameter_to_artifact_pipeline.task_inputs == {
         "a": InputParameter(name="a")
         .set_owner(parameter_to_artifact_pipeline)
@@ -94,6 +97,7 @@ def test_parameter_pipeline(test_output_dir):
     assert adding_parameters_pipeline.registered_namespace is None
 
     # --- validate pipeline instance's io attributes
+    # test outputs of `build_inputs_from_func`
     assert adding_parameters_pipeline.inputs == {
         "a": InputParameter(name="a", value=1).set_owner(
             adding_parameters_pipeline
@@ -103,11 +107,13 @@ def test_parameter_pipeline(test_output_dir):
         ),
     }
     assert adding_parameters_pipeline.required_inputs == {}
+    # test outputs of `build_outputs_from_func`
     # we dont have access to the output's Component type owner, so can only
     # verify the name here.
     assert list(adding_parameters_pipeline.outputs.keys()) == [
         "sum",
     ]
+    # test outputs of `build_task_inputs`
     assert adding_parameters_pipeline.task_inputs == {
         "a": InputParameter(name="a")
         .set_owner(adding_parameters_pipeline)

--- a/sdk/test/unit/pipelines/pipeline/test_pipeline.py
+++ b/sdk/test/unit/pipelines/pipeline/test_pipeline.py
@@ -3,7 +3,7 @@ from bettmensch_ai.pipelines.pipeline.examples import (
     adding_parameters_pipeline,
     parameter_to_artifact_pipeline,
 )
-from hera.workflows import Artifact, Parameter
+from hera.workflows import Artifact, Parameter, models
 
 
 def test_artifact_pipeline(
@@ -132,7 +132,9 @@ def test_parameter_pipeline(test_output_dir):
     assert inner_dag_template.outputs == [
         Parameter(
             name="sum",
-            value="{{tasks.a-plus-b-plus-2-0.outputs.parameters.sum}}",
+            value_from=models.ValueFrom(
+                parameter="{{tasks.a-plus-b-plus-2-0.outputs.parameters.sum}}"
+            ),
         ),
     ]
     inner_dag_template_tasks = inner_dag_template.tasks

--- a/sdk/test/unit/pipelines/pipeline/test_pipeline.py
+++ b/sdk/test/unit/pipelines/pipeline/test_pipeline.py
@@ -11,13 +11,17 @@ def test_artifact_pipeline(
 ):
     """Declaration of Pipeline using InputArtifact and OutputArtifact"""
 
+    # export pipeline to allow for manual checks
+    parameter_to_artifact_pipeline.export(test_output_dir)
+
+    # --- validate pipeline instance's basic attributes
     assert parameter_to_artifact_pipeline.built
     assert not parameter_to_artifact_pipeline.registered
     assert parameter_to_artifact_pipeline.registered_id is None
     assert parameter_to_artifact_pipeline.registered_name is None
     assert parameter_to_artifact_pipeline.registered_namespace is None
 
-    # --- validate class' io attributes
+    # --- validate pipeline instance's io attributes
     assert parameter_to_artifact_pipeline.inputs == {
         "a": InputParameter(name="a", value="Param A").set_owner(
             parameter_to_artifact_pipeline
@@ -35,7 +39,7 @@ def test_artifact_pipeline(
         .set_source(parameter_to_artifact_pipeline.inputs["a"]),
     }
 
-    # --- validate class' `user_built_workflow_template` attribute
+    # --- validate pipeline instance's `user_built_workflow_template` attribute
     wft = parameter_to_artifact_pipeline.user_built_workflow_template
 
     # validate spec
@@ -75,20 +79,21 @@ def test_artifact_pipeline(
         Parameter(name="a", value="{{workflow.parameters.a}}"),
     ]
 
-    parameter_to_artifact_pipeline.export(test_output_dir)
-
 
 def test_parameter_pipeline(test_output_dir):
     """Declaration of Pipeline using InputParameter and OutputParameter"""
 
-    # --- validate class' basic attributes
+    # export pipeline to allow for manual checks
+    adding_parameters_pipeline.export(test_output_dir)
+
+    # --- validate pipeline instance's basic attributes
     assert adding_parameters_pipeline.built
     assert not adding_parameters_pipeline.registered
     assert adding_parameters_pipeline.registered_id is None
     assert adding_parameters_pipeline.registered_name is None
     assert adding_parameters_pipeline.registered_namespace is None
 
-    # --- validate class' io attributes
+    # --- validate pipeline instance's io attributes
     assert adding_parameters_pipeline.inputs == {
         "a": InputParameter(name="a", value=1).set_owner(
             adding_parameters_pipeline
@@ -112,7 +117,7 @@ def test_parameter_pipeline(test_output_dir):
         .set_source(adding_parameters_pipeline.inputs["b"]),
     }
 
-    # --- validate class' `user_built_workflow_template` attribute
+    # --- validate pipeline instance's `user_built_workflow_template` attribute
     wft = adding_parameters_pipeline.user_built_workflow_template
 
     # validate spec
@@ -159,5 +164,3 @@ def test_parameter_pipeline(test_output_dir):
         Parameter(name="a", value="{{workflow.parameters.a}}"),
         Parameter(name="b", value="{{workflow.parameters.b}}"),
     ]
-
-    adding_parameters_pipeline.export(test_output_dir)

--- a/sdk/test/unit/pipelines/pipeline/test_pipeline.py
+++ b/sdk/test/unit/pipelines/pipeline/test_pipeline.py
@@ -32,18 +32,25 @@ def test_artifact_pipeline(
     assert parameter_to_artifact.registered_id is None
     assert parameter_to_artifact.registered_name is None
     assert parameter_to_artifact.registered_namespace is None
-    assert set(parameter_to_artifact.inputs.keys()) == {"a"}
+    assert set(parameter_to_artifact.workflow_template_inputs.keys()) == {"a"}
+    assert set(parameter_to_artifact.inner_dag_task_inputs.keys()) == {"a"}
     for pipeline_input_name, pipeline_input_default in (("a", "Param A"),):
         assert (
-            parameter_to_artifact.inputs[pipeline_input_name].name
+            parameter_to_artifact.workflow_template_inputs[
+                pipeline_input_name
+            ].name
             == pipeline_input_name
         )
         assert (
-            parameter_to_artifact.inputs[pipeline_input_name].owner
+            parameter_to_artifact.workflow_template_inputs[
+                pipeline_input_name
+            ].owner
             == parameter_to_artifact
         )
         assert (
-            parameter_to_artifact.inputs[pipeline_input_name].value
+            parameter_to_artifact.workflow_template_inputs[
+                pipeline_input_name
+            ].value
             == pipeline_input_default
         )
     assert isinstance(
@@ -60,9 +67,10 @@ def test_artifact_pipeline(
 
     script_template_names = [template.name for template in wft.templates]
     assert script_template_names == [
-        "bettmensch-ai-dag",
+        "bettmensch-ai-inner-dag",
         "convert-to-artifact",
         "show-artifact",
+        "bettmensch-ai-outer-dag",
     ]
 
     parameter_to_artifact.export(test_output_dir)
@@ -92,18 +100,25 @@ def test_parameter_pipeline(test_output_dir):
     assert adding_parameters.registered_id is None
     assert adding_parameters.registered_name is None
     assert adding_parameters.registered_namespace is None
-    assert set(adding_parameters.inputs.keys()) == {"a", "b"}
+    assert set(adding_parameters.workflow_template_inputs.keys()) == {"a", "b"}
+    assert set(adding_parameters.inner_dag_task_inputs.keys()) == {"a", "b"}
     for pipeline_input_name, pipeline_input_default in (("a", 1), ("b", 2)):
         assert (
-            adding_parameters.inputs[pipeline_input_name].name
+            adding_parameters.workflow_template_inputs[
+                pipeline_input_name
+            ].name
             == pipeline_input_name
         )
         assert (
-            adding_parameters.inputs[pipeline_input_name].owner
+            adding_parameters.workflow_template_inputs[
+                pipeline_input_name
+            ].owner
             == adding_parameters
         )
         assert (
-            adding_parameters.inputs[pipeline_input_name].value
+            adding_parameters.workflow_template_inputs[
+                pipeline_input_name
+            ].value
             == pipeline_input_default
         )
 
@@ -117,9 +132,10 @@ def test_parameter_pipeline(test_output_dir):
 
     script_template_names = [template.name for template in wft.templates]
     assert script_template_names == [
-        "bettmensch-ai-dag",
+        "bettmensch-ai-inner-dag",
         "a-plus-b",
         "a-plus-b-plus-2",
+        "bettmensch-ai-outer-dag",
     ]
 
     adding_parameters.export(test_output_dir)

--- a/sdk/test/unit/pipelines/test_io.py
+++ b/sdk/test/unit/pipelines/test_io.py
@@ -143,12 +143,21 @@ def test_input_artifact_to_hera(
             ),
         ),
         (
-            "test_mock_component",
+            "test_mock_pipeline",
             InputParameter("test_source_name"),
             "test_mock_pipeline",
             Parameter(
                 name="test_name",
                 value="{{workflow.parameters.test_source_name}}",
+            ),
+        ),
+        (
+            "test_mock_component",
+            InputParameter("test_source_name"),
+            "test_mock_pipeline",
+            Parameter(
+                name="test_name",
+                value="{{inputs.parameters.test_source_name}}",
             ),
         ),
     ],


### PR DESCRIPTION
Main piece of work was adding a nested DAG to the workflow templates representing a pipeline to 
- add pipeline outputs, and
- keep pipeline inputs and new outputs in one place - that nested dag's inputs and outputs. Previously the pipeline inputs where specified as workflow template arguments.

Updated example pipelines to have outputs.

Also improved the unit and k8s tests for core component and pipeline classes. All passing.