### PR TITLE
Fix bugs introduced in last PR #50

### DIFF
--- a/sdk/bettmensch_ai/pipelines/component/examples/basic.py
+++ b/sdk/bettmensch_ai/pipelines/component/examples/basic.py
@@ -3,6 +3,7 @@ from bettmensch_ai.pipelines.component import (  # noqa: F401
     as_component,
     as_torch_ddp_component,
 )
+from bettmensch_ai.pipelines.constants import COMPONENT_IMPLEMENTATION
 from bettmensch_ai.pipelines.io import (  # noqa: F401
     InputArtifact,
     InputParameter,
@@ -57,35 +58,35 @@ def show_parameter(a: InputParameter) -> None:
 
 convert_to_artifact_factory = as_component(convert_to_artifact)
 convert_to_artifact_adapter_out_factory = as_adapter_component(
-    "adapter_out", convert_to_artifact
+    COMPONENT_IMPLEMENTATION.adapter_out.value, convert_to_artifact
 )
 convert_to_artifact_adapter_in_factory = as_adapter_component(
-    "adapter_in", convert_to_artifact
+    COMPONENT_IMPLEMENTATION.adapter_in.value, convert_to_artifact
 )
 convert_to_artifact_torch_ddp_factory = as_torch_ddp_component(
     convert_to_artifact
 )  # noqa: E501
 show_artifact_factory = as_component(show_artifact)
 show_artifact_adapter_out_factory = as_adapter_component(
-    "adapter_out", show_artifact
+    COMPONENT_IMPLEMENTATION.adapter_out.value, show_artifact
 )
 show_artifact_adapter_in_factory = as_adapter_component(
-    "adapter_in", show_artifact
+    COMPONENT_IMPLEMENTATION.adapter_in.value, show_artifact
 )
 show_artifact_torch_ddp_factory = as_torch_ddp_component(show_artifact)
 add_parameters_factory = as_component(add_parameters)
 add_parameters_adapter_out_factory = as_adapter_component(
-    "adapter_out", add_parameters
+    COMPONENT_IMPLEMENTATION.adapter_out.value, add_parameters
 )
 add_parameters_adapter_in_factory = as_adapter_component(
-    "adapter_in", add_parameters
+    COMPONENT_IMPLEMENTATION.adapter_in.value, add_parameters
 )
 add_parameters_torch_ddp_factory = as_torch_ddp_component(add_parameters)
 show_parameter_factory = as_component(show_parameter)
 show_parameter_adapter_out_factory = as_adapter_component(
-    "adapter_out", show_parameter
+    COMPONENT_IMPLEMENTATION.adapter_out.value, show_parameter
 )
 show_parameter_adapter_in_factory = as_adapter_component(
-    "adapter_in", show_parameter
+    COMPONENT_IMPLEMENTATION.adapter_in.value, show_parameter
 )
 show_parameter_torch_ddp_factory = as_torch_ddp_component(show_parameter)

--- a/sdk/bettmensch_ai/pipelines/constants.py
+++ b/sdk/bettmensch_ai/pipelines/constants.py
@@ -71,7 +71,12 @@ class COMPONENT_IMPLEMENTATION(Enum):
     adapter_out: str = "adapter_out"
     adapter_in: str = "adapter_in"
     wait_on_k8s_external: str = "wait_on_k8s_external"
-    torch_ddp: str = "torch-ddp"
+    torch_ddp: str = "torch_ddp"
+
+
+class PipelineDagTemplate(Enum):
+    inner: str = "bettmensch-ai-inner-dag"
+    outer: str = "bettmensch-ai-outer-dag"
 
 
 class TORCH_DDP_SCRIPT_IMPLEMENTATION(Enum):

--- a/sdk/bettmensch_ai/pipelines/constants.py
+++ b/sdk/bettmensch_ai/pipelines/constants.py
@@ -68,10 +68,10 @@ GPU_TOLERATION = Toleration(
 class COMPONENT_IMPLEMENTATION(Enum):
     base: str = "base"
     standard: str = "standard"
-    adapter_out: str = "adapter_out"
-    adapter_in: str = "adapter_in"
-    wait_on_k8s_external: str = "wait_on_k8s_external"
-    torch_ddp: str = "torch_ddp"
+    adapter_out: str = "adapter-out"
+    adapter_in: str = "adapter-in"
+    wait_on_k8s_external: str = "wait-on-k8s-external"
+    torch_ddp: str = "torch-ddp"
 
 
 class PipelineDagTemplate(Enum):

--- a/sdk/test/unit/pipelines/component/test_adapter_component.py
+++ b/sdk/test/unit/pipelines/component/test_adapter_component.py
@@ -38,7 +38,7 @@ def test_adapter_out_component___init__(test_function_and_task_inputs):
 
     # validate component attributes
     assert isinstance(test_component, AdapterOutComponent)
-    assert test_component.implementation == "adapter_out"
+    assert test_component.implementation == "adapter-out"
     assert test_component.base_name == "test-name-adapter-out"
     assert test_component.name == "test-name-adapter-out-0"
     assert test_component.depends == "mock-component-0"
@@ -68,7 +68,7 @@ def test_adapter_in_component___init__(test_function_and_task_inputs):
 
     # validate component attributes
     assert isinstance(test_component, AdapterInComponent)
-    assert test_component.implementation == "adapter_in"
+    assert test_component.implementation == "adapter-in"
     assert test_component.base_name == "test-name-adapter-in"
     assert test_component.name == "test-name-adapter-in-0"
     assert test_component.depends == "mock-component-0"


### PR DESCRIPTION
Fixes two bugs introduced in PR #50 

# Fix 1
The underscore in `torch_ddp` gets replaced when populating the `base_name` attribute of the `TorchDDPComponent` class instance, but is not being replaced when building the k8s service related creation and deletion templates.

Fix is to use dashes in all `COMPONENT_IMPLEMENTATION` enum values.

# Fix 2
Adding constant for the dag template names and additional step to retrieve the workflow template's _inner_ dag template when (re-)building inputs.