### PR TITLE
Disable scheduled platform test

### DIFF
--- a/.github/workflows/platform-test.yaml
+++ b/.github/workflows/platform-test.yaml
@@ -1,13 +1,13 @@
-name: Scheduled platform test
-on:
-  schedule:
-    - cron: '00 01 */2 * *' # run this test at 16:40 UTC every day
-jobs:
-  k8s-test:
-    uses: ./.github/workflows/test.yaml
-    secrets: inherit
-    with:
-      test-suite: k8s
-      test-flags: ""
-      python-version: "3.10"
-      deprovision-when-finished: true
+# name: Scheduled platform test
+# on:
+#   schedule:
+#     - cron: '00 01 */2 * *' # run this test at 16:40 UTC every day
+# jobs:
+#   k8s-test:
+#     uses: ./.github/workflows/test.yaml
+#     secrets: inherit
+#     with:
+#       test-suite: k8s
+#       test-flags: ""
+#       python-version: "3.10"
+#       deprovision-when-finished: true


### PR DESCRIPTION
Disabling scheduled test to reduce cost and mitigate karpenter node deprovisioning failures